### PR TITLE
Remove forced v3.0.0 for ohdearapp/ohdear-php-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ This cron check at Oh Dear is currently in beta, and you'll have to [request](ma
 To get started you will first need to install the Oh Dear SDK.
  
 ```bash
-composer require ohdearapp/ohdear-php-sdk:v3
+composer require ohdearapp/ohdear-php-sdk
 ```
  
  Next you, need to make sure the `api_token` and `site_id` keys of the `schedule-monitor` are filled with an API token, and an Oh Dear site id. To verify that these values hold correct values you can run this command.


### PR DESCRIPTION
The current line `composer require ohdearapp/ohdear-php-sdk:v3` forces installation of v3.0.0 which is not compatible with Guzzle7 (and therefore not with Laravel 8).

![image](https://user-images.githubusercontent.com/25909128/94584128-870f6500-027e-11eb-9c0f-ba5041943418.png)
