### PR TITLE
Update create_schedule_monitor_tables.php.stub

### DIFF
--- a/database/migrations/create_schedule_monitor_tables.php.stub
+++ b/database/migrations/create_schedule_monitor_tables.php.stub
@@ -47,4 +47,10 @@ class CreateScheduleMonitorTables extends Migration
             $table->timestamps();
         });
     }
+    
+    public function down()
+    {
+        Schema::dropIfExists('monitored_scheduled_task_log_items');
+        Schema::dropIfExists('monitored_scheduled_tasks');
+    }
 }


### PR DESCRIPTION
php artisan migrate:fresh stops working because of "Base table or view already exists"