### PR TITLE
DB connection can be set in the env that is different to the default db.

### DIFF
--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -14,6 +14,12 @@ return [
      */
     'date_format' => 'Y-m-d H:i:s',
 
+    /**
+     * Specify a different db connection to use for schedule monitoring logs.
+     * Used default connection if not specified.
+     */
+    'db_connection' => env('SCHEDULE_MONITOR_DB_CONNECTION'),
+
     /*
      * Oh Dear can notify you via Mail, Slack, SMS, web hooks, ... when a
      * scheduled task does not run on time.

--- a/src/Models/MonitoredScheduledTask.php
+++ b/src/Models/MonitoredScheduledTask.php
@@ -28,6 +28,14 @@ class MonitoredScheduledTask extends Model
         'grace_time_in_minutes' => 'integer',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        if($connection = config('schedule-monitor.db_connection')){
+            $this->setConnection($connection);
+        }
+    }
+
     public function logItems(): HasMany
     {
         return $this->hasMany(MonitoredScheduledTaskLogItem::class)->orderByDesc('id');

--- a/src/Models/MonitoredScheduledTaskLogItem.php
+++ b/src/Models/MonitoredScheduledTaskLogItem.php
@@ -18,6 +18,15 @@ class MonitoredScheduledTaskLogItem extends Model
         'meta' => 'array',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        // $this->connection = config('schedule-monitor.db_connection') ?? config('database.default');
+        parent::__construct($attributes);
+        if($connection = config('schedule-monitor.db_connection')){
+            $this->setConnection($connection);
+        }
+    }
+
     public function monitoredScheduledTask(): BelongsTo
     {
         return $this->belongsTo(MonitoredScheduledTask::class);


### PR DESCRIPTION
Add db connection env variable to be used by schedule monitoring logs
`SCHEDULE_MONITOR_DB_CONNECTION=dbconnectionname`

The migration does not require it as it can be specified when the migration is run with the --database option.