### PR TITLE
Store output v2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
-            testbench: 6.*
+            testbench: ^6.8
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,19 @@ protected function schedule(Schedule $schedule)
 }
 ```
 
+### Storing output to database
+
+You can store the output by tacking on `storeOutputToDb` when scheduling the task.
+
+```php
+// in app/Console/Kernel.php
+
+protected function schedule(Schedule $schedule)
+{
+   $schedule->command('your-command')->daily()->storeOutputToDb();
+}
+```
+
 ### Getting notified when a scheduled task doesn't finish in time
 
 This package can sync your schedule with the [Oh Dear](https://ohdear.app) cron check. Oh Dear will send you a notification whenever a scheduled task does not finish on time.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "laravel/legacy-factories": "^1.0.4",
         "ohdearapp/ohdear-php-sdk": "^3.0",
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^6.8",
         "phpunit/phpunit": "^9.3",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2",

--- a/src/Models/MonitoredScheduledTask.php
+++ b/src/Models/MonitoredScheduledTask.php
@@ -182,6 +182,10 @@ class MonitoredScheduledTask extends Model
      */
     protected function getEventTaskOutput($event): ?string
     {
+        if (! ($event->task->storeOutputToDb ?? false)) {
+            return null;
+        }
+
         if (is_null($event->task->output)) {
             return null;
         }

--- a/src/Models/MonitoredScheduledTask.php
+++ b/src/Models/MonitoredScheduledTask.php
@@ -94,6 +94,7 @@ class MonitoredScheduledTask extends Model
             'runtime' => $event->task->runInBackground ? 0 : $event->runtime,
             'exit_code' => $event->task->exitCode,
             'memory' => $event->task->runInBackground ? 0 : memory_get_usage(true),
+            'output' => $this->getEventTaskOutput($event),
         ]);
 
         $this->update(['last_finished_at' => now()]);
@@ -174,5 +175,27 @@ class MonitoredScheduledTask extends Model
         return $this->logItems()->create([
             'type' => $type,
         ]);
+    }
+
+    /**
+     * @param ScheduledTaskFailed|ScheduledTaskFinished $event
+     */
+    protected function getEventTaskOutput($event): ?string
+    {
+        if (is_null($event->task->output)) {
+            return null;
+        }
+
+        if ($event->task->output === $event->task->getDefaultOutput()) {
+            return null;
+        }
+
+        if (! is_file($event->task->output)) {
+            return null;
+        }
+
+        $output = file_get_contents($event->task->output);
+
+        return $output ?: null;
     }
 }

--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -103,6 +103,13 @@ class ScheduleMonitorServiceProvider extends ServiceProvider
             return $this;
         });
 
+        SchedulerEvent::macro('storeOutputToDb', function () {
+            $this->storeOutputToDb = true;
+            $this->ensureOutputIsBeingCaptured();
+
+            return $this;
+        });
+
         return $this;
     }
 }

--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -105,6 +105,7 @@ class ScheduleMonitorServiceProvider extends ServiceProvider
 
         SchedulerEvent::macro('storeOutputToDb', function () {
             $this->storeOutputToDb = true;
+            /** @psalm-suppress UndefinedMethod */
             $this->ensureOutputIsBeingCaptured();
 
             return $this;

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -4,7 +4,6 @@ namespace Spatie\ScheduleMonitor\Tests\ScheduledTaskSubscriber;
 
 use Exception;
 use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Bus;
 use Spatie\ScheduleMonitor\Commands\SyncCommand;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
@@ -174,6 +173,6 @@ class ScheduledTaskSubscriberTest extends TestCase
         $task = MonitoredScheduledTask::findByName('dummy-task');
         $logItem = $task->logItems()->where('type', MonitoredScheduledTaskLogItem::TYPE_FINISHED)->first();
 
-        $this->assertTrue(Str::contains($logItem->meta['output'] ?? '', 'Display help for a command'));
+        $this->assertStringContainsString('help for a command', $logItem->meta['output'] ?? '');
     }
 }

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Spatie\ScheduleMonitor\Tests\ScheduledTaskSubscriber;
 use Exception;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\File;
 use Spatie\ScheduleMonitor\Commands\SyncCommand;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
@@ -25,6 +26,15 @@ class ScheduledTaskSubscriberTest extends TestCase
         TestKernel::registerScheduledTasks(function (Schedule $schedule) {
             $schedule->call(fn () => 1 + 1)->everyMinute()->monitorName('dummy-task');
         });
+
+        File::copy(__DIR__.'/../stubs/artisan', base_path('artisan'));
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        File::delete(base_path('artisan'));
     }
 
     /** @test */
@@ -96,6 +106,8 @@ class ScheduledTaskSubscriberTest extends TestCase
     /** @test */
     public function it_will_mark_a_task_as_failed_when_it_throws_an_exception()
     {
+        File::delete(base_path('artisan'));
+
         TestKernel::replaceScheduledTasks(function (Schedule $schedule) {
             $schedule->command(FailingCommand::class)->everyMinute();
         });
@@ -157,8 +169,6 @@ class ScheduledTaskSubscriberTest extends TestCase
     /** @test */
     public function it_stores_the_command_output()
     {
-        copy(__DIR__.'/../stubs/artisan', base_path('artisan'));
-
         TestKernel::replaceScheduledTasks(function (Schedule $schedule) {
             $schedule
                 ->command('help')

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -173,7 +173,7 @@ class ScheduledTaskSubscriberTest extends TestCase
             $schedule
                 ->command('help')
                 ->everyMinute()
-                ->storeOutput()
+                ->storeOutputToDb()
                 ->monitorName('dummy-task');
         });
 

--- a/tests/stubs/artisan
+++ b/tests/stubs/artisan
@@ -1,0 +1,53 @@
+#!/usr/bin/env php
+<?php
+
+define('LARAVEL_START', microtime(true));
+
+/*
+|--------------------------------------------------------------------------
+| Register The Auto Loader
+|--------------------------------------------------------------------------
+|
+| Composer provides a convenient, automatically generated class loader
+| for our application. We just need to utilize it! We'll require it
+| into the script here so that we do not have to worry about the
+| loading of any of our classes manually. It's great to relax.
+|
+*/
+
+require __DIR__.'/../../../autoload.php';
+
+$app = require_once __DIR__.'/bootstrap/app.php';
+
+/*
+|--------------------------------------------------------------------------
+| Run The Artisan Application
+|--------------------------------------------------------------------------
+|
+| When we run the console application, the current CLI command will be
+| executed in this console and the response sent back to a terminal
+| or another output device for the developers. Here goes nothing!
+|
+*/
+
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+
+$status = $kernel->handle(
+    $input = new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+
+/*
+|--------------------------------------------------------------------------
+| Shutdown The Application
+|--------------------------------------------------------------------------
+|
+| Once Artisan has finished running, we will fire off the shutdown events
+| so that any final work may be done by the application before we shut
+| down the process. This is the last thing to happen to the request.
+|
+*/
+
+$kernel->terminate($input, $status);
+
+exit($status);


### PR DESCRIPTION
This extends #42 by testing with an actual command (`php artisan help`). I had to include the `artisan` script since Testbench doesn't have it.