### PR TITLE
Automatically retry ping if OhDear had downtime

### DIFF
--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -37,7 +37,7 @@ class PingOhDearJob implements ShouldQueue
             return;
         }
 
-        $response = Http::post($payload->url(), $payload->data());
+        $response = Http::retry(3, 10)->post($payload->url(), $payload->data());
         $response->throw();
 
         $this->logItem->monitoredScheduledTask->update(['last_pinged_at' => now()]);

--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -37,7 +37,7 @@ class PingOhDearJob implements ShouldQueue
             return;
         }
 
-        $response = Http::retry(3, 10)->post($payload->url(), $payload->data());
+        $response = Http::retry(3, 10 * 1000)->post($payload->url(), $payload->data());
         $response->throw();
 
         $this->logItem->monitoredScheduledTask->update(['last_pinged_at' => now()]);


### PR DESCRIPTION
## Issue

Yesterday and today I had 5 pings failing due to a 500 Internal server error on OhDear side. 

- 30-07-2021: 19:00 (Europe/Amsterdam)
- 31-07-2021 06:00 (2x), 15:00, 21:00  (Europe/Amsterdam)

As reference the OhDear ids: sites/16574/checks/97683/cron/4337

I have just retried them via Horizon and then they get accepted. (However as I noticed it too late, OhDear has marked the cron as failed). My queuing setup on this project is very simple, so there's only 1 attempt at running the job.

## Possible solution

To not depend on user land queue settings, it might be good to leverage the Laravel Http client's build in retry() method. I've set it to 3 retries with a 10 second delay in between, but you might be a better judge of the numbers that would work better based on how long the above described 500 errors lasted.

## Alternatives

As jobs have a default timeout, long downtimes wouldn't be tackled with just retrying the request. A backoff strategy (https://laravel.com/docs/8.x/queues#dealing-with-failed-jobs) could be used as well. If you would prefer that approach (or a combination), I'm happy to update the PR to that.