### PR TITLE
Add retryUntil for PingOhdearJobs

### DIFF
--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -54,5 +54,11 @@ return [
          * via a queued job. Here you can specify the name of the queue you wish to use.
          */
         'queue' => env('OH_DEAR_QUEUE'),
+
+        /*
+         * `PingOhDearJob`s will automatically be skipped if they've been queued for
+         * longer than the time configured here.
+         */
+        'retry_job_for_minutes' => 10,
     ],
 ];

--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\ScheduleMonitor\Jobs;
 
-use Carbon\Carbon;
 use DateTime;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\ScheduleMonitor\Jobs;
 
+use Carbon\Carbon;
+use DateTime;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -41,5 +43,10 @@ class PingOhDearJob implements ShouldQueue
         $response->throw();
 
         $this->logItem->monitoredScheduledTask->update(['last_pinged_at' => now()]);
+    }
+
+    public function retryUntil(): DateTime
+    {
+        return now()->addMinutes(config('schedule-monitor.oh_dear.retry_job_for_minutes', 10));
     }
 }


### PR DESCRIPTION
If there's a backlog of ping-jobs, ohdear will rate limit the application. This will cause 20 second time-outs on the jobs and a blocked queue. This PR makes sure that the old backlog of ping-jobs doesn't run when it's no longer relevant.

Suggestions on how to test this are welcome 