### PR TITLE
Take environments property into account for scheduled tasks

### DIFF
--- a/src/Support/ScheduledTasks/ScheduledTasks.php
+++ b/src/Support/ScheduledTasks/ScheduledTasks.php
@@ -25,6 +25,9 @@ class ScheduledTasks
         $this->schedule = $schedule;
 
         $this->tasks = collect($this->schedule->events())
+            ->filter(
+                fn (Event $event): bool => $event->runsInEnvironment(config('app.env'))
+            )
             ->map(
                 fn (Event $event): Task => ScheduledTaskFactory::createForEvent($event)
             );

--- a/tests/Support/ScheduledTasksTest.php
+++ b/tests/Support/ScheduledTasksTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\ScheduleMonitor\Tests\Support;
 
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Config;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\ScheduledTasks;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
 use Spatie\ScheduleMonitor\Tests\TestCase;
@@ -37,5 +38,24 @@ class ScheduledTasksTest extends TestCase
         $this->assertEquals([
             'dummy-closure',
         ], $duplicateTasks);
+    }
+    
+    /** @test */
+    public function it_can_get_only_the_tasks_that_run_in_the_current_environment_from_the_schedule()
+    {
+        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+            $schedule->command('dummy')->environments('testing'); // current
+            $schedule->command('other-dummy')->environments('production'); 
+        });
+
+        $scheduledTasks = ScheduledTasks::createForSchedule();
+
+        $uniqueTasks = $scheduledTasks->uniqueTasks()
+            ->map(fn (Task $task) => "{$task->name()}-{$task->type()}")
+            ->toArray();
+
+        $this->assertEquals([
+            'dummy-command',
+        ], $uniqueTasks);
     }
 }


### PR DESCRIPTION
Fixed issue described in this discussion: https://github.com/spatie/laravel-schedule-monitor/discussions/49