### PR TITLE
Make sure retryUntil is returning a DateTime

### DIFF
--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -46,6 +46,6 @@ class PingOhDearJob implements ShouldQueue
 
     public function retryUntil(): DateTime
     {
-        return now()->addMinutes(config('schedule-monitor.oh_dear.retry_job_for_minutes', 10));
+        return now()->addMinutes(config('schedule-monitor.oh_dear.retry_job_for_minutes', 10))->toDateTime();
     }
 }


### PR DESCRIPTION
In my Laravel application I'm using immutable dates (following this article https://dyrynda.com.au/blog/laravel-immutable-dates), so `now()` return `CarbonImmutable` and not `Carbon`.
Because of that this `retryUntil` function fails for me (https://flareapp.io/share/NPLk99om#F33), adding `toDateTime()` at the end make sure the return type is correct.