### PR TITLE
Fix return type

### DIFF
--- a/src/Models/MonitoredScheduledTaskLogItem.php
+++ b/src/Models/MonitoredScheduledTaskLogItem.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder;
 use Spatie\ScheduleMonitor\Support\Concerns\UsesScheduleMonitoringModels;
 
 class MonitoredScheduledTaskLogItem extends Model


### PR DESCRIPTION
Fixes the following error:

```
Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem::prunable(): Return value must be of type Illuminate\Database\Query\Builder, Illuminate\Database\Eloquent\Builder returned
```