### PR TITLE
Update readme about model pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('model:prune', ['--model' => MonitoredScheduledTaskLogItem::class])->daily()
+        $schedule->command('model:prune', ['--model' => MonitoredScheduledTaskLogItem::class])->daily();
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -123,11 +123,13 @@ Use [Laravel's model pruning feature](https://laravel.com/docs/9.x/eloquent#mass
 ```php
 // app/Console/Kernel.php
 
+use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
+
 class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('model:prune')->daily();
+        $schedule->command('model:prune', ['--model' => MonitoredScheduledTaskLogItem::class])->daily()
     }
 }
 ```


### PR DESCRIPTION
When running `model:prune` it doesn't find the `MonitoredScheduledTaskLogItem` model, unless I put it in my models folder and extend it. It seems it's a missing feature in Laravel to have prunable models in a package (currently only looks in `app/Models`).

Passing the model directly in the command, fixes that issue until Laravel adds support for it.

