### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
+        "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,13 @@
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {
+        "mockery/mockery": "^1.4",
         "ohdearapp/ohdear-php-sdk": "^3.0",
         "orchestra/testbench": "^7.0",
+        "pestphp/pest": "^1.20",
+        "pestphp/pest-plugin-laravel": "^1.2",
         "spatie/phpunit-snapshot-assertions": "^4.2",
-        "spatie/test-time": "^1.2",
-        "mockery/mockery": "^1.4",
-        "pestphp/pest": "^1.20"
+        "spatie/test-time": "^1.2"
     },
     "suggest": {
         "ohdearapp/ohdear-php-sdk": "Needed to sync your schedule with Oh Dear"

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     "require-dev": {
         "ohdearapp/ohdear-php-sdk": "^3.0",
         "orchestra/testbench": "^7.0",
-        "phpunit/phpunit": "^9.4",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2",
-        "mockery/mockery": "^1.4"
+        "mockery/mockery": "^1.4",
+        "pestphp/pest": "^1.20"
     },
     "suggest": {
         "ohdearapp/ohdear-php-sdk": "Needed to sync your schedule with Oh Dear"

--- a/tests/Commands/ListCommandTest.php
+++ b/tests/Commands/ListCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Commands\ListCommand;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestJob;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
+use function Pest\Laravel\artisan;
 
 it('can list scheduled tasks', function () {
     TestKernel::registerScheduledTasks(function (Schedule $schedule) {
@@ -16,5 +17,5 @@ it('can list scheduled tasks', function () {
         $schedule->job(new TestJob())->daily();
     });
 
-    $this->artisan(ListCommand::class)->assertSuccessful();
+    artisan(ListCommand::class)->assertSuccessful();
 });

--- a/tests/Commands/SyncCommandTest.php
+++ b/tests/Commands/SyncCommandTest.php
@@ -9,9 +9,6 @@ use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
 use Spatie\Snapshots\MatchesSnapshots;
 use Spatie\TestTime\TestTime;
 
-uses(TestCase::class);
-uses(MatchesSnapshots::class);
-
 beforeEach(function () {
     TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
 });

--- a/tests/Commands/SyncCommandTest.php
+++ b/tests/Commands/SyncCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\Commands;
-
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Commands\SyncCommand;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
@@ -11,192 +9,171 @@ use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
 use Spatie\Snapshots\MatchesSnapshots;
 use Spatie\TestTime\TestTime;
 
-class SyncCommandTest extends TestCase
-{
-    use MatchesSnapshots;
+uses(TestCase::class);
+uses(MatchesSnapshots::class);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
+});
 
-        TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
-    }
+it('can sync the schedule with the db and oh dear', function () {
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->everyMinute();
+        $schedule->exec('execute')->everyFifteenMinutes();
+        $schedule->call(fn () => 1 + 1)->hourly()->monitorName('my-closure');
+        $schedule->job(new TestJob())->daily()->timezone('Asia/Kolkata');
+    });
 
-    /** @test */
-    public function it_can_sync_the_schedule_with_the_db_and_oh_dear()
-    {
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('dummy')->everyMinute();
-            $schedule->exec('execute')->everyFifteenMinutes();
-            $schedule->call(fn () => 1 + 1)->hourly()->monitorName('my-closure');
-            $schedule->job(new TestJob())->daily()->timezone('Asia/Kolkata');
-        });
+    $this->artisan(SyncCommand::class);
 
-        $this->artisan(SyncCommand::class);
+    $monitoredScheduledTasks = MonitoredScheduledTask::get();
+    $this->assertCount(4, $monitoredScheduledTasks);
 
-        $monitoredScheduledTasks = MonitoredScheduledTask::get();
-        $this->assertCount(4, $monitoredScheduledTasks);
+    $this->assertDatabaseHas('monitored_scheduled_tasks', [
+        'name' => 'dummy',
+        'type' => 'command',
+        'cron_expression' => '* * * * *',
+        'ping_url' => 'https://ping.ohdear.app/test-ping-url-dummy',
+        'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
+        'grace_time_in_minutes' => 5,
+        'last_pinged_at' => null,
+        'last_started_at' => null,
+        'last_finished_at' => null,
+        'timezone' => 'UTC',
+    ]);
 
-        $this->assertDatabaseHas('monitored_scheduled_tasks', [
-            'name' => 'dummy',
-            'type' => 'command',
-            'cron_expression' => '* * * * *',
-            'ping_url' => 'https://ping.ohdear.app/test-ping-url-dummy',
-            'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
-            'grace_time_in_minutes' => 5,
-            'last_pinged_at' => null,
-            'last_started_at' => null,
-            'last_finished_at' => null,
-            'timezone' => 'UTC',
-        ]);
+    $this->assertDatabaseHas('monitored_scheduled_tasks', [
+        'name' => 'execute',
+        'type' => 'shell',
+        'cron_expression' => '*/15 * * * *',
+        'ping_url' => 'https://ping.ohdear.app/test-ping-url-execute',
+        'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
+        'grace_time_in_minutes' => 5,
+        'last_pinged_at' => null,
+        'last_started_at' => null,
+        'last_finished_at' => null,
+        'timezone' => 'UTC',
+    ]);
 
-        $this->assertDatabaseHas('monitored_scheduled_tasks', [
-            'name' => 'execute',
-            'type' => 'shell',
-            'cron_expression' => '*/15 * * * *',
-            'ping_url' => 'https://ping.ohdear.app/test-ping-url-execute',
-            'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
-            'grace_time_in_minutes' => 5,
-            'last_pinged_at' => null,
-            'last_started_at' => null,
-            'last_finished_at' => null,
-            'timezone' => 'UTC',
-        ]);
+    $this->assertDatabaseHas('monitored_scheduled_tasks', [
+        'name' => 'my-closure',
+        'type' => 'closure',
+        'cron_expression' => '0 * * * *',
+        'ping_url' => 'https://ping.ohdear.app/test-ping-url-my-closure',
+        'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
+        'grace_time_in_minutes' => 5,
+        'last_pinged_at' => null,
+        'last_started_at' => null,
+        'last_finished_at' => null,
+        'timezone' => 'UTC',
+    ]);
 
-        $this->assertDatabaseHas('monitored_scheduled_tasks', [
-            'name' => 'my-closure',
-            'type' => 'closure',
-            'cron_expression' => '0 * * * *',
-            'ping_url' => 'https://ping.ohdear.app/test-ping-url-my-closure',
-            'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
-            'grace_time_in_minutes' => 5,
-            'last_pinged_at' => null,
-            'last_started_at' => null,
-            'last_finished_at' => null,
-            'timezone' => 'UTC',
-        ]);
+    $this->assertDatabaseHas('monitored_scheduled_tasks', [
+        'name' => TestJob::class,
+        'type' => 'job',
+        'cron_expression' => '0 0 * * *',
+        'ping_url' => 'https://ping.ohdear.app/test-ping-url-' . urlencode(TestJob::class),
+        'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
+        'grace_time_in_minutes' => 5,
+        'last_pinged_at' => null,
+        'last_started_at' => null,
+        'last_finished_at' => null,
+        'timezone' => 'Asia/Kolkata',
+    ]);
 
-        $this->assertDatabaseHas('monitored_scheduled_tasks', [
-            'name' => TestJob::class,
-            'type' => 'job',
-            'cron_expression' => '0 0 * * *',
-            'ping_url' => 'https://ping.ohdear.app/test-ping-url-' . urlencode(TestJob::class),
-            'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
-            'grace_time_in_minutes' => 5,
-            'last_pinged_at' => null,
-            'last_started_at' => null,
-            'last_finished_at' => null,
-            'timezone' => 'Asia/Kolkata',
-        ]);
+    $this->assertMatchesSnapshot($this->ohDear->getSyncedCronCheckAttributes());
+});
 
-        $this->assertMatchesSnapshot($this->ohDear->getSyncedCronCheckAttributes());
-    }
+it('will not monitor commands without a name', function () {
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->call(fn () => 'a closure has no name')->hourly();
+    });
 
-    /** @test */
-    public function it_will_not_monitor_commands_without_a_name()
-    {
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->call(fn () => 'a closure has no name')->hourly();
-        });
+    $this->artisan(SyncCommand::class);
 
-        $this->artisan(SyncCommand::class);
+    $monitoredScheduledTasks = MonitoredScheduledTask::get();
+    $this->assertCount(0, $monitoredScheduledTasks);
 
-        $monitoredScheduledTasks = MonitoredScheduledTask::get();
-        $this->assertCount(0, $monitoredScheduledTasks);
+    $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
+});
 
-        $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
-    }
+it('will remove old tasks from the database', function () {
+    MonitoredScheduledTask::factory()->create(['name' => 'old-task']);
+    $this->assertCount(1, MonitoredScheduledTask::get());
 
-    /** @test **/
-    public function it_will_remove_old_tasks_from_the_database()
-    {
-        MonitoredScheduledTask::factory()->create(['name' => 'old-task']);
-        $this->assertCount(1, MonitoredScheduledTask::get());
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('new')->everyMinute();
+    });
 
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('new')->everyMinute();
-        });
+    $this->artisan(SyncCommand::class);
 
-        $this->artisan(SyncCommand::class);
+    $this->assertCount(1, MonitoredScheduledTask::get());
 
-        $this->assertCount(1, MonitoredScheduledTask::get());
+    $this->assertEquals('new', MonitoredScheduledTask::first()->name);
+});
 
-        $this->assertEquals('new', MonitoredScheduledTask::first()->name);
-    }
+it('can use custom grace time', function () {
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->everyMinute()->graceTimeInMinutes(15);
+    });
 
-    /** @test */
-    public function it_can_use_custom_grace_time()
-    {
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('dummy')->everyMinute()->graceTimeInMinutes(15);
-        });
+    $this->artisan(SyncCommand::class);
 
-        $this->artisan(SyncCommand::class);
+    $this->assertDatabaseHas('monitored_scheduled_tasks', [
+        'grace_time_in_minutes' => 15,
+    ]);
 
-        $this->assertDatabaseHas('monitored_scheduled_tasks', [
-            'grace_time_in_minutes' => 15,
-        ]);
+    $syncedCronChecks = $this->ohDear->getSyncedCronCheckAttributes();
 
-        $syncedCronChecks = $this->ohDear->getSyncedCronCheckAttributes();
+    $this->assertEquals(15, $syncedCronChecks[0]['grace_time_in_minutes']);
+});
 
-        $this->assertEquals(15, $syncedCronChecks[0]['grace_time_in_minutes']);
-    }
+it('will not monitor tasks that should not be monitored', function () {
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->everyMinute()->doNotMonitor();
+    });
 
-    /** @test */
-    public function it_will_not_monitor_tasks_that_should_not_be_monitored()
-    {
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('dummy')->everyMinute()->doNotMonitor();
-        });
+    $this->artisan(SyncCommand::class);
 
-        $this->artisan(SyncCommand::class);
+    $this->assertCount(0, MonitoredScheduledTask::get());
 
-        $this->assertCount(0, MonitoredScheduledTask::get());
+    $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
+});
 
-        $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
-    }
+it('will remove tasks from the db that should not be monitored anymore', function () {
+    MonitoredScheduledTask::factory()->create(['name' => 'not-monitored']);
+    $this->assertCount(1, MonitoredScheduledTask::get());
 
-    /** @test */
-    public function it_will_remove_tasks_from_the_db_that_should_not_be_monitored_anymore()
-    {
-        MonitoredScheduledTask::factory()->create(['name' => 'not-monitored']);
-        $this->assertCount(1, MonitoredScheduledTask::get());
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('not-monitored')->everyMinute()->doNotMonitor();
+    });
+    $this->artisan(SyncCommand::class);
 
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('not-monitored')->everyMinute()->doNotMonitor();
-        });
-        $this->artisan(SyncCommand::class);
+    $this->assertCount(0, MonitoredScheduledTask::get());
+});
 
-        $this->assertCount(0, MonitoredScheduledTask::get());
-    }
+it('will update tasks that have their schedule updated', function () {
+    $monitoredScheduledTask = MonitoredScheduledTask::factory()->create([
+        'name' => 'dummy',
+        'cron_expression' => '* * * * *',
+    ]);
 
-    /** @test */
-    public function it_will_update_tasks_that_have_their_schedule_updated()
-    {
-        $monitoredScheduledTask = MonitoredScheduledTask::factory()->create([
-            'name' => 'dummy',
-            'cron_expression' => '* * * * *',
-        ]);
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->daily();
+    });
+    $this->artisan(SyncCommand::class);
 
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('dummy')->daily();
-        });
-        $this->artisan(SyncCommand::class);
+    $this->assertCount(1, MonitoredScheduledTask::get());
+    $this->assertEquals('0 0 * * *', $monitoredScheduledTask->refresh()->cron_expression);
+});
 
-        $this->assertCount(1, MonitoredScheduledTask::get());
-        $this->assertEquals('0 0 * * *', $monitoredScheduledTask->refresh()->cron_expression);
-    }
+it('will not sync with oh dear when no site id is set', function () {
+    config()->set('schedule-monitor.oh_dear.site_id', null);
 
-    /** @test */
-    public function it_will_not_sync_with_oh_dear_when_no_site_id_is_set()
-    {
-        config()->set('schedule-monitor.oh_dear.site_id', null);
-
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('dummy')->daily();
-        });
-        $this->artisan(SyncCommand::class);
-        $this->assertCount(1, MonitoredScheduledTask::get());
-        $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
-    }
-}
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->daily();
+    });
+    $this->artisan(SyncCommand::class);
+    $this->assertCount(1, MonitoredScheduledTask::get());
+    $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
+});

--- a/tests/Commands/SyncCommandTest.php
+++ b/tests/Commands/SyncCommandTest.php
@@ -27,7 +27,7 @@ it('can sync the schedule with the db and oh dear', function () {
     $this->artisan(SyncCommand::class);
 
     $monitoredScheduledTasks = MonitoredScheduledTask::get();
-    $this->assertCount(4, $monitoredScheduledTasks);
+    expect($monitoredScheduledTasks)->toHaveCount(4);
 
     $this->assertDatabaseHas('monitored_scheduled_tasks', [
         'name' => 'dummy',
@@ -92,14 +92,14 @@ it('will not monitor commands without a name', function () {
     $this->artisan(SyncCommand::class);
 
     $monitoredScheduledTasks = MonitoredScheduledTask::get();
-    $this->assertCount(0, $monitoredScheduledTasks);
+    expect($monitoredScheduledTasks)->toHaveCount(0);
 
-    $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
+    expect($this->ohDear->getSyncedCronCheckAttributes())->toEqual([]);
 });
 
 it('will remove old tasks from the database', function () {
     MonitoredScheduledTask::factory()->create(['name' => 'old-task']);
-    $this->assertCount(1, MonitoredScheduledTask::get());
+    expect(MonitoredScheduledTask::get())->toHaveCount(1);
 
     TestKernel::registerScheduledTasks(function (Schedule $schedule) {
         $schedule->command('new')->everyMinute();
@@ -107,9 +107,9 @@ it('will remove old tasks from the database', function () {
 
     $this->artisan(SyncCommand::class);
 
-    $this->assertCount(1, MonitoredScheduledTask::get());
+    expect(MonitoredScheduledTask::get())->toHaveCount(1);
 
-    $this->assertEquals('new', MonitoredScheduledTask::first()->name);
+    expect(MonitoredScheduledTask::first()->name)->toEqual('new');
 });
 
 it('can use custom grace time', function () {
@@ -125,7 +125,7 @@ it('can use custom grace time', function () {
 
     $syncedCronChecks = $this->ohDear->getSyncedCronCheckAttributes();
 
-    $this->assertEquals(15, $syncedCronChecks[0]['grace_time_in_minutes']);
+    expect($syncedCronChecks[0]['grace_time_in_minutes'])->toEqual(15);
 });
 
 it('will not monitor tasks that should not be monitored', function () {
@@ -135,21 +135,21 @@ it('will not monitor tasks that should not be monitored', function () {
 
     $this->artisan(SyncCommand::class);
 
-    $this->assertCount(0, MonitoredScheduledTask::get());
+    expect(MonitoredScheduledTask::get())->toHaveCount(0);
 
-    $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
+    expect($this->ohDear->getSyncedCronCheckAttributes())->toEqual([]);
 });
 
 it('will remove tasks from the db that should not be monitored anymore', function () {
     MonitoredScheduledTask::factory()->create(['name' => 'not-monitored']);
-    $this->assertCount(1, MonitoredScheduledTask::get());
+    expect(MonitoredScheduledTask::get())->toHaveCount(1);
 
     TestKernel::registerScheduledTasks(function (Schedule $schedule) {
         $schedule->command('not-monitored')->everyMinute()->doNotMonitor();
     });
     $this->artisan(SyncCommand::class);
 
-    $this->assertCount(0, MonitoredScheduledTask::get());
+    expect(MonitoredScheduledTask::get())->toHaveCount(0);
 });
 
 it('will update tasks that have their schedule updated', function () {
@@ -163,8 +163,8 @@ it('will update tasks that have their schedule updated', function () {
     });
     $this->artisan(SyncCommand::class);
 
-    $this->assertCount(1, MonitoredScheduledTask::get());
-    $this->assertEquals('0 0 * * *', $monitoredScheduledTask->refresh()->cron_expression);
+    expect(MonitoredScheduledTask::get())->toHaveCount(1);
+    expect($monitoredScheduledTask->refresh()->cron_expression)->toEqual('0 0 * * *');
 });
 
 it('will not sync with oh dear when no site id is set', function () {
@@ -174,6 +174,6 @@ it('will not sync with oh dear when no site id is set', function () {
         $schedule->command('dummy')->daily();
     });
     $this->artisan(SyncCommand::class);
-    $this->assertCount(1, MonitoredScheduledTask::get());
-    $this->assertEquals([], $this->ohDear->getSyncedCronCheckAttributes());
+    expect(MonitoredScheduledTask::get())->toHaveCount(1);
+    expect($this->ohDear->getSyncedCronCheckAttributes())->toEqual([]);
 });

--- a/tests/Commands/VerifyCommandTest.php
+++ b/tests/Commands/VerifyCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Exception;
 use Spatie\ScheduleMonitor\Commands\VerifyCommand;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 

--- a/tests/Commands/VerifyCommandTest.php
+++ b/tests/Commands/VerifyCommandTest.php
@@ -1,36 +1,27 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\Commands;
-
 use Exception;
 use Spatie\ScheduleMonitor\Commands\VerifyCommand;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 
-class VerifyCommandTest extends TestCase
-{
-    /** @test */
-    public function it_can_verify_the_connection_to_oh_dear()
-    {
-        $this->artisan(VerifyCommand::class)->assertExitCode(0);
-    }
+uses(TestCase::class);
 
-    /** @test */
-    public function it_will_throw_an_exception_if_the_api_token_is_not_set()
-    {
-        config()->set('schedule-monitor.oh_dear.api_token', null);
+it('can verify the connection to oh dear', function () {
+    $this->artisan(VerifyCommand::class)->assertExitCode(0);
+});
 
-        $this->expectException(Exception::class);
+it('will throw an exception if the api token is not set', function () {
+    config()->set('schedule-monitor.oh_dear.api_token', null);
 
-        $this->artisan(VerifyCommand::class)->assertExitCode(0);
-    }
+    $this->expectException(Exception::class);
 
-    /** @test */
-    public function it_will_throw_an_exception_if_the_site_id_is_not_set()
-    {
-        config()->set('schedule-monitor.oh_dear.site_id', null);
+    $this->artisan(VerifyCommand::class)->assertExitCode(0);
+});
 
-        $this->expectException(Exception::class);
+it('will throw an exception if the site id is not set', function () {
+    config()->set('schedule-monitor.oh_dear.site_id', null);
 
-        $this->artisan(VerifyCommand::class)->assertExitCode(0);
-    }
-}
+    $this->expectException(Exception::class);
+
+    $this->artisan(VerifyCommand::class)->assertExitCode(0);
+});

--- a/tests/Commands/VerifyCommandTest.php
+++ b/tests/Commands/VerifyCommandTest.php
@@ -3,8 +3,6 @@
 use Spatie\ScheduleMonitor\Commands\VerifyCommand;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 
-uses(TestCase::class);
-
 it('can verify the connection to oh dear', function () {
     $this->artisan(VerifyCommand::class)->assertExitCode(0);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,4 @@
 <?php
 
-use Spatie\ScheduleMonitor\Tests\TestCase;
 
 uses(\Spatie\ScheduleMonitor\Tests\TestCase::class)->in('__DIR__', 'ScheduledTaskSubscriber', 'Support', 'Traits');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,4 +1,6 @@
 <?php
 
+use Spatie\ScheduleMonitor\Tests\TestCase;
+use Spatie\Snapshots\MatchesSnapshots;
 
-uses(\Spatie\ScheduleMonitor\Tests\TestCase::class)->in('__DIR__', 'ScheduledTaskSubscriber', 'Support', 'Traits');
+uses(TestCase::class, MatchesSnapshots::class)->in(__DIR__);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,4 +2,4 @@
 
 use Spatie\ScheduleMonitor\Tests\TestCase;
 
-uses(TestCase::class)->in(__DIR__);
+uses(\Spatie\ScheduleMonitor\Tests\TestCase::class)->in('__DIR__', 'ScheduledTaskSubscriber', 'Support', 'Traits');

--- a/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
@@ -4,9 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
-use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
-
 
 beforeEach(function () {
     TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');

--- a/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\ScheduledTaskSubscriber;
-
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
@@ -9,51 +7,41 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-class PingFailedToOhDearTest extends TestCase
-{
-    private MonitoredScheduledTaskLogItem $monitoredScheduledTaskLogItem;
+uses(TestCase::class);
 
-    private array $meta;
+beforeEach(function () {
+    TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    Http::fake([
+        'ping.ohdear.app/*' => Http::response('ok', 200),
+    ]);
 
-        TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
+    $this->meta = [
+        'failure_message' => 'failure',
+    ];
 
-        Http::fake([
-            'ping.ohdear.app/*' => Http::response('ok', 200),
-        ]);
+    $this->monitoredScheduledTaskLogItem = MonitoredScheduledTaskLogItem::factory()->create([
+        'type' => MonitoredScheduledTaskLogItem::TYPE_FAILED,
+        'meta' => $this->meta,
+    ]);
+});
 
-        $this->meta = [
-            'failure_message' => 'failure',
-        ];
+it('can ping oh dear when a scheduled task fails', function () {
+    dispatch(new PingOhDearJob($this->monitoredScheduledTaskLogItem));
 
-        $this->monitoredScheduledTaskLogItem = MonitoredScheduledTaskLogItem::factory()->create([
-            'type' => MonitoredScheduledTaskLogItem::TYPE_FAILED,
-            'meta' => $this->meta,
-        ]);
-    }
+    $this->assertEquals(
+        $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->refresh()->last_pinged_at->format('Y-m-d H:i:s'),
+        now()->format('Y-m-d H:i:s'),
+    );
 
-    /** @test */
-    public function it_can_ping_oh_dear_when_a_scheduled_task_fails()
-    {
-        dispatch(new PingOhDearJob($this->monitoredScheduledTaskLogItem));
-
+    Http::assertSent(function (Request $request) {
         $this->assertEquals(
-            $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->refresh()->last_pinged_at->format('Y-m-d H:i:s'),
-            now()->format('Y-m-d H:i:s'),
+            $request->url(),
+            $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->ping_url . '/failed'
         );
 
-        Http::assertSent(function (Request $request) {
-            $this->assertEquals(
-                $request->url(),
-                $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->ping_url . '/failed'
-            );
+        $this->assertEquals($this->meta, $request->data());
 
-            $this->assertEquals($this->meta, $request->data());
-
-            return true;
-        });
-    }
-}
+        return true;
+    });
+});

--- a/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
@@ -40,7 +40,7 @@ it('can ping oh dear when a scheduled task fails', function () {
             $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->ping_url . '/failed'
         );
 
-        $this->assertEquals($this->meta, $request->data());
+        expect($request->data())->toEqual($this->meta);
 
         return true;
     });

--- a/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFailedToOhDearTest.php
@@ -7,7 +7,6 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');

--- a/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
@@ -4,9 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
-use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
-
 
 beforeEach(function () {
     TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');

--- a/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\ScheduledTaskSubscriber;
-
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
@@ -9,53 +7,43 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-class PingFinishedToOhDearTest extends TestCase
-{
-    private MonitoredScheduledTaskLogItem $monitoredScheduledTaskLogItem;
+uses(TestCase::class);
 
-    private array $meta;
+beforeEach(function () {
+    TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    Http::fake([
+        'ping.ohdear.app/*' => Http::response('ok', 200),
+    ]);
 
-        TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
+    $this->meta = [
+        'runtime' => 12.34,
+        'exit_code' => 123,
+        'memory' => 12345,
+    ];
 
-        Http::fake([
-            'ping.ohdear.app/*' => Http::response('ok', 200),
-        ]);
+    $this->monitoredScheduledTaskLogItem = MonitoredScheduledTaskLogItem::factory()->create([
+        'type' => MonitoredScheduledTaskLogItem::TYPE_FINISHED,
+        'meta' => $this->meta,
+    ]);
+});
 
-        $this->meta = [
-            'runtime' => 12.34,
-            'exit_code' => 123,
-            'memory' => 12345,
-        ];
+it('can ping oh dear when a scheduled task finishes', function () {
+    dispatch(new PingOhDearJob($this->monitoredScheduledTaskLogItem));
 
-        $this->monitoredScheduledTaskLogItem = MonitoredScheduledTaskLogItem::factory()->create([
-            'type' => MonitoredScheduledTaskLogItem::TYPE_FINISHED,
-            'meta' => $this->meta,
-        ]);
-    }
+    $this->assertEquals(
+        $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->refresh()->last_pinged_at->format('Y-m-d H:i:s'),
+        now()->format('Y-m-d H:i:s'),
+    );
 
-    /** @test */
-    public function it_can_ping_oh_dear_when_a_scheduled_task_finishes()
-    {
-        dispatch(new PingOhDearJob($this->monitoredScheduledTaskLogItem));
-
+    Http::assertSent(function (Request $request) {
         $this->assertEquals(
-            $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->refresh()->last_pinged_at->format('Y-m-d H:i:s'),
-            now()->format('Y-m-d H:i:s'),
+            $request->url(),
+            $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->ping_url . '/finished'
         );
 
-        Http::assertSent(function (Request $request) {
-            $this->assertEquals(
-                $request->url(),
-                $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->ping_url . '/finished'
-            );
+        $this->assertEquals($this->meta, $request->data());
 
-            $this->assertEquals($this->meta, $request->data());
-
-            return true;
-        });
-    }
-}
+        return true;
+    });
+});

--- a/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
@@ -7,7 +7,6 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');

--- a/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
+++ b/tests/ScheduledTaskSubscriber/PingFinishedToOhDearTest.php
@@ -42,7 +42,7 @@ it('can ping oh dear when a scheduled task finishes', function () {
             $this->monitoredScheduledTaskLogItem->monitoredScheduledTask->ping_url . '/finished'
         );
 
-        $this->assertEquals($this->meta, $request->data());
+        expect($request->data())->toEqual($this->meta);
 
         return true;
     });

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -12,7 +12,6 @@ use Spatie\ScheduleMonitor\Tests\TestClasses\FailingCommand;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
 use Spatie\TestTime\TestTime;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     Bus::fake();

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -145,7 +145,7 @@ it('stores the command output to db', function () {
     $task = MonitoredScheduledTask::findByName('dummy-task');
     $logItem = $task->logItems()->where('type', MonitoredScheduledTaskLogItem::TYPE_FINISHED)->first();
 
-    $this->assertStringContainsString('help for a command', $logItem->meta['output'] ?? '');
+    expect($logItem->meta['output'] ?? '')->toContain('help for a command');
 });
 
 it('does not store the command output to db', function () {
@@ -162,5 +162,5 @@ it('does not store the command output to db', function () {
     $task = MonitoredScheduledTask::findByName('dummy-task');
     $logItem = $task->logItems()->where('type', MonitoredScheduledTaskLogItem::TYPE_FINISHED)->first();
 
-    $this->assertNull($logItem->meta['output']);
+    expect($logItem->meta['output'])->toBeNull();
 });

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Exception;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\File;

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -7,11 +7,9 @@ use Spatie\ScheduleMonitor\Commands\SyncCommand;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
-use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\ScheduleMonitor\Tests\TestClasses\FailingCommand;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
 use Spatie\TestTime\TestTime;
-
 
 beforeEach(function () {
     Bus::fake();

--- a/tests/Support/ScheduledTasksTest.php
+++ b/tests/Support/ScheduledTasksTest.php
@@ -3,9 +3,7 @@
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\ScheduledTasks;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
-use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
-
 
 it('can get the unique and duplicate tasks from the schedule', function () {
     TestKernel::registerScheduledTasks(function (Schedule $schedule) {

--- a/tests/Support/ScheduledTasksTest.php
+++ b/tests/Support/ScheduledTasksTest.php
@@ -1,60 +1,53 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\Support;
-
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\ScheduledTasks;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
 
-class ScheduledTasksTest extends TestCase
-{
-    /** @test */
-    public function it_can_get_the_unique_and_duplicate_tasks_from_the_schedule()
-    {
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('dummy')->everyMinute();
-            $schedule->call(fn () => 1 + 1)->hourly()->monitorName('dummy');
-            $schedule->command('other-dummy')->everyMinute();
-        });
+uses(TestCase::class);
 
-        $scheduledTasks = ScheduledTasks::createForSchedule();
+it('can get the unique and duplicate tasks from the schedule', function () {
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->everyMinute();
+        $schedule->call(fn () => 1 + 1)->hourly()->monitorName('dummy');
+        $schedule->command('other-dummy')->everyMinute();
+    });
 
-        $uniqueTasks = $scheduledTasks->uniqueTasks()
-            ->map(fn (Task $task) => "{$task->name()}-{$task->type()}")
-            ->toArray();
+    $scheduledTasks = ScheduledTasks::createForSchedule();
 
-        $this->assertEquals([
-            'dummy-command',
-            'other-dummy-command',
-        ], $uniqueTasks);
+    $uniqueTasks = $scheduledTasks->uniqueTasks()
+        ->map(fn (Task $task) => "{$task->name()}-{$task->type()}")
+        ->toArray();
 
-        $duplicateTasks = $scheduledTasks->duplicateTasks()
-            ->map(fn (Task $task) => "{$task->name()}-{$task->type()}")
-            ->toArray();
+    $this->assertEquals([
+        'dummy-command',
+        'other-dummy-command',
+    ], $uniqueTasks);
 
-        $this->assertEquals([
-            'dummy-closure',
-        ], $duplicateTasks);
-    }
-    
-    /** @test */
-    public function it_can_get_only_the_tasks_that_run_in_the_current_environment_from_the_schedule()
-    {
-        TestKernel::registerScheduledTasks(function (Schedule $schedule) {
-            $schedule->command('dummy')->environments('testing'); // current
-            $schedule->command('other-dummy')->environments('production');
-        });
+    $duplicateTasks = $scheduledTasks->duplicateTasks()
+        ->map(fn (Task $task) => "{$task->name()}-{$task->type()}")
+        ->toArray();
 
-        $scheduledTasks = ScheduledTasks::createForSchedule();
+    $this->assertEquals([
+        'dummy-closure',
+    ], $duplicateTasks);
+});
 
-        $uniqueTasks = $scheduledTasks->uniqueTasks()
-            ->map(fn (Task $task) => "{$task->name()}-{$task->type()}")
-            ->toArray();
+it('can get only the tasks that run in the current environment from the schedule', function () {
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->environments('testing'); // current
+        $schedule->command('other-dummy')->environments('production');
+    });
 
-        $this->assertEquals([
-            'dummy-command',
-        ], $uniqueTasks);
-    }
-}
+    $scheduledTasks = ScheduledTasks::createForSchedule();
+
+    $uniqueTasks = $scheduledTasks->uniqueTasks()
+        ->map(fn (Task $task) => "{$task->name()}-{$task->type()}")
+        ->toArray();
+
+    $this->assertEquals([
+        'dummy-command',
+    ], $uniqueTasks);
+});

--- a/tests/Support/ScheduledTasksTest.php
+++ b/tests/Support/ScheduledTasksTest.php
@@ -6,7 +6,6 @@ use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
 
-uses(TestCase::class);
 
 it('can get the unique and duplicate tasks from the schedule', function () {
     TestKernel::registerScheduledTasks(function (Schedule $schedule) {

--- a/tests/Support/ScheduledTestFactoryTest.php
+++ b/tests/Support/ScheduledTestFactoryTest.php
@@ -6,10 +6,8 @@ use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\ClosureTask;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\CommandTask;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\JobTask;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\ShellTask;
-use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestJob;
 use Spatie\TestTime\TestTime;
-
 
 it('will return a command task for a scheduled command task', function () {
     $event = app()->make(Schedule::class)->command('foo:bar');

--- a/tests/Support/ScheduledTestFactoryTest.php
+++ b/tests/Support/ScheduledTestFactoryTest.php
@@ -17,8 +17,8 @@ it('will return a command task for a scheduled command task', function () {
 
     $task = ScheduledTaskFactory::createForEvent($event);
 
-    $this->assertInstanceOf(CommandTask::class, $task);
-    $this->assertEquals('foo:bar', $task->name());
+    expect($task)->toBeInstanceOf(CommandTask::class);
+    expect($task->name())->toEqual('foo:bar');
 });
 
 it('will return a shell task for a scheduled shell task', function () {
@@ -26,8 +26,8 @@ it('will return a shell task for a scheduled shell task', function () {
 
     $task = ScheduledTaskFactory::createForEvent($event);
 
-    $this->assertInstanceOf(ShellTask::class, $task);
-    $this->assertEquals('a bash command', $task->name());
+    expect($task)->toBeInstanceOf(ShellTask::class);
+    expect($task->name())->toEqual('a bash command');
 });
 
 it('will return a job task for a scheduled job task', function () {
@@ -35,8 +35,8 @@ it('will return a job task for a scheduled job task', function () {
 
     $task = ScheduledTaskFactory::createForEvent($event);
 
-    $this->assertInstanceOf(JobTask::class, $task);
-    $this->assertEquals(TestJob::class, $task->name());
+    expect($task)->toBeInstanceOf(JobTask::class);
+    expect($task->name())->toEqual(TestJob::class);
 });
 
 it('will return a closure task for a scheduled closure task', function () {
@@ -46,8 +46,8 @@ it('will return a closure task for a scheduled closure task', function () {
 
     $task = ScheduledTaskFactory::createForEvent($event);
 
-    $this->assertInstanceOf(ClosureTask::class, $task);
-    $this->assertNull($task->name());
+    expect($task)->toBeInstanceOf(ClosureTask::class);
+    expect($task->name())->toBeNull();
 });
 
 test('the task name can be manually set', function () {
@@ -55,15 +55,15 @@ test('the task name can be manually set', function () {
 
     $task = ScheduledTaskFactory::createForEvent($event);
 
-    $this->assertEquals('my-custom-name', $task->name());
+    expect($task->name())->toEqual('my-custom-name');
 });
 
 test('a task can be marked as not to be monitored', function () {
     $event = app()->make(Schedule::class)->command('foo:bar');
-    $this->assertTrue(ScheduledTaskFactory::createForEvent($event)->shouldMonitor());
+    expect(ScheduledTaskFactory::createForEvent($event)->shouldMonitor())->toBeTrue();
 
     $event = app()->make(Schedule::class)->command('foo:bar')->doNotMonitor();
-    $this->assertFalse(ScheduledTaskFactory::createForEvent($event)->shouldMonitor());
+    expect(ScheduledTaskFactory::createForEvent($event)->shouldMonitor())->toBeFalse();
 });
 
 it('can handle timezones', function () {
@@ -73,11 +73,11 @@ it('can handle timezones', function () {
 
     $appTimezoneEvent = $schedule->command('foo:bar')->daily();
     $appTimezoneTask = ScheduledTaskFactory::createForEvent($appTimezoneEvent);
-    $this->assertEquals('UTC', $appTimezoneTask->timezone());
-    $this->assertEquals('2020-02-02 00:00:00', $appTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'));
+    expect($appTimezoneTask->timezone())->toEqual('UTC');
+    expect($appTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'))->toEqual('2020-02-02 00:00:00');
 
     $otherTimezoneEvent = $schedule->command('foo:bar')->daily()->timezone('Asia/Kolkata');
     $otherTimezoneTask = ScheduledTaskFactory::createForEvent($otherTimezoneEvent);
-    $this->assertEquals('Asia/Kolkata', $otherTimezoneTask->timezone());
-    $this->assertEquals('2020-02-01 18:30:00', $otherTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'));
+    expect($otherTimezoneTask->timezone())->toEqual('Asia/Kolkata');
+    expect($otherTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'))->toEqual('2020-02-01 18:30:00');
 });

--- a/tests/Support/ScheduledTestFactoryTest.php
+++ b/tests/Support/ScheduledTestFactoryTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\Support;
-
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\ScheduledTaskFactory;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\ClosureTask;
@@ -12,89 +10,74 @@ use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestJob;
 use Spatie\TestTime\TestTime;
 
-class ScheduledTestFactoryTest extends TestCase
-{
-    /** @test */
-    public function it_will_return_a_command_task_for_a_scheduled_command_task()
-    {
-        $event = $this->app->make(Schedule::class)->command('foo:bar');
+uses(TestCase::class);
 
-        $task = ScheduledTaskFactory::createForEvent($event);
+it('will return a command task for a scheduled command task', function () {
+    $event = app()->make(Schedule::class)->command('foo:bar');
 
-        $this->assertInstanceOf(CommandTask::class, $task);
-        $this->assertEquals('foo:bar', $task->name());
-    }
+    $task = ScheduledTaskFactory::createForEvent($event);
 
-    /** @test */
-    public function it_will_return_a_shell_task_for_a_scheduled_shell_task()
-    {
-        $event = $this->app->make(Schedule::class)->exec('a bash command');
+    $this->assertInstanceOf(CommandTask::class, $task);
+    $this->assertEquals('foo:bar', $task->name());
+});
 
-        $task = ScheduledTaskFactory::createForEvent($event);
+it('will return a shell task for a scheduled shell task', function () {
+    $event = app()->make(Schedule::class)->exec('a bash command');
 
-        $this->assertInstanceOf(ShellTask::class, $task);
-        $this->assertEquals('a bash command', $task->name());
-    }
+    $task = ScheduledTaskFactory::createForEvent($event);
 
-    /** @test */
-    public function it_will_return_a_job_task_for_a_scheduled_job_task()
-    {
-        $event = $this->app->make(Schedule::class)->job(new TestJob());
+    $this->assertInstanceOf(ShellTask::class, $task);
+    $this->assertEquals('a bash command', $task->name());
+});
 
-        $task = ScheduledTaskFactory::createForEvent($event);
+it('will return a job task for a scheduled job task', function () {
+    $event = app()->make(Schedule::class)->job(new TestJob());
 
-        $this->assertInstanceOf(JobTask::class, $task);
-        $this->assertEquals(TestJob::class, $task->name());
-    }
+    $task = ScheduledTaskFactory::createForEvent($event);
 
-    /** @test */
-    public function it_will_return_a_closure_task_for_a_scheduled_closure_task()
-    {
-        $event = $this->app->make(Schedule::class)->call(function () {
-            $i = 1;
-        });
+    $this->assertInstanceOf(JobTask::class, $task);
+    $this->assertEquals(TestJob::class, $task->name());
+});
 
-        $task = ScheduledTaskFactory::createForEvent($event);
+it('will return a closure task for a scheduled closure task', function () {
+    $event = app()->make(Schedule::class)->call(function () {
+        $i = 1;
+    });
 
-        $this->assertInstanceOf(ClosureTask::class, $task);
-        $this->assertNull($task->name());
-    }
+    $task = ScheduledTaskFactory::createForEvent($event);
 
-    /** @test */
-    public function the_task_name_can_be_manually_set()
-    {
-        $event = $this->app->make(Schedule::class)->command('foo:bar')->monitorName('my-custom-name');
+    $this->assertInstanceOf(ClosureTask::class, $task);
+    $this->assertNull($task->name());
+});
 
-        $task = ScheduledTaskFactory::createForEvent($event);
+test('the task name can be manually set', function () {
+    $event = app()->make(Schedule::class)->command('foo:bar')->monitorName('my-custom-name');
 
-        $this->assertEquals('my-custom-name', $task->name());
-    }
+    $task = ScheduledTaskFactory::createForEvent($event);
 
-    /** @test */
-    public function a_task_can_be_marked_as_not_to_be_monitored()
-    {
-        $event = $this->app->make(Schedule::class)->command('foo:bar');
-        $this->assertTrue(ScheduledTaskFactory::createForEvent($event)->shouldMonitor());
+    $this->assertEquals('my-custom-name', $task->name());
+});
 
-        $event = $this->app->make(Schedule::class)->command('foo:bar')->doNotMonitor();
-        $this->assertFalse(ScheduledTaskFactory::createForEvent($event)->shouldMonitor());
-    }
+test('a task can be marked as not to be monitored', function () {
+    $event = app()->make(Schedule::class)->command('foo:bar');
+    $this->assertTrue(ScheduledTaskFactory::createForEvent($event)->shouldMonitor());
 
-    /** @test */
-    public function it_can_handle_timezones()
-    {
-        TestTime::freeze('Y-m-d H:i:s', '2020-02-01 00:00:00');
+    $event = app()->make(Schedule::class)->command('foo:bar')->doNotMonitor();
+    $this->assertFalse(ScheduledTaskFactory::createForEvent($event)->shouldMonitor());
+});
 
-        $schedule = $this->app->make(Schedule::class);
+it('can handle timezones', function () {
+    TestTime::freeze('Y-m-d H:i:s', '2020-02-01 00:00:00');
 
-        $appTimezoneEvent = $schedule->command('foo:bar')->daily();
-        $appTimezoneTask = ScheduledTaskFactory::createForEvent($appTimezoneEvent);
-        $this->assertEquals('UTC', $appTimezoneTask->timezone());
-        $this->assertEquals('2020-02-02 00:00:00', $appTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'));
+    $schedule = app()->make(Schedule::class);
 
-        $otherTimezoneEvent = $schedule->command('foo:bar')->daily()->timezone('Asia/Kolkata');
-        $otherTimezoneTask = ScheduledTaskFactory::createForEvent($otherTimezoneEvent);
-        $this->assertEquals('Asia/Kolkata', $otherTimezoneTask->timezone());
-        $this->assertEquals('2020-02-01 18:30:00', $otherTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'));
-    }
-}
+    $appTimezoneEvent = $schedule->command('foo:bar')->daily();
+    $appTimezoneTask = ScheduledTaskFactory::createForEvent($appTimezoneEvent);
+    $this->assertEquals('UTC', $appTimezoneTask->timezone());
+    $this->assertEquals('2020-02-02 00:00:00', $appTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'));
+
+    $otherTimezoneEvent = $schedule->command('foo:bar')->daily()->timezone('Asia/Kolkata');
+    $otherTimezoneTask = ScheduledTaskFactory::createForEvent($otherTimezoneEvent);
+    $this->assertEquals('Asia/Kolkata', $otherTimezoneTask->timezone());
+    $this->assertEquals('2020-02-01 18:30:00', $otherTimezoneTask->nextRunAt()->format('Y-m-d H:i:s'));
+});

--- a/tests/Support/ScheduledTestFactoryTest.php
+++ b/tests/Support/ScheduledTestFactoryTest.php
@@ -10,7 +10,6 @@ use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestJob;
 use Spatie\TestTime\TestTime;
 
-uses(TestCase::class);
 
 it('will return a command task for a scheduled command task', function () {
     $event = app()->make(Schedule::class)->command('foo:bar');

--- a/tests/Support/Tasks/LastRunFailedTest.php
+++ b/tests/Support/Tasks/LastRunFailedTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\Support\Tasks;
-
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
@@ -10,65 +8,50 @@ use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-class LastRunFailedTest extends TestCase
+uses(TestCase::class);
+
+beforeEach(function () {
+    TestTime::freeze();
+
+    $this->event = app()->make(Schedule::class)->command('foo:bar');
+
+    $this->monitoredScheduledTask = MonitoredScheduledTask::factory()->create([
+        'name' => 'foo:bar',
+    ]);
+});
+
+it('will return false if it didnt start or fail yet', function () {
+    $this->assertFalse(task()->lastRunFailed());
+});
+
+it('will return false if it did start but not fail yet', function () {
+    $this->monitoredScheduledTask->update(['last_started_at' => now()]);
+
+    $this->assertFalse(task()->lastRunFailed());
+});
+
+it('will return true if it failed after it started', function () {
+    $this->monitoredScheduledTask->update(['last_started_at' => now()]);
+
+    TestTime::addMinute();
+
+    $this->monitoredScheduledTask->update(['last_failed_at' => now()]);
+
+    $this->assertTrue(task()->lastRunFailed());
+});
+
+it('will return false if it started after it failed', function () {
+    $this->monitoredScheduledTask->update(['last_failed_at' => now()]);
+
+    TestTime::addMinute();
+
+    $this->monitoredScheduledTask->update(['last_started_at' => now()]);
+
+    $this->assertFalse(task()->lastRunFailed());
+});
+
+// Helpers
+function task(): Task
 {
-    private Event $event;
-
-    private MonitoredScheduledTask $monitoredScheduledTask;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        TestTime::freeze();
-
-        $this->event = $this->app->make(Schedule::class)->command('foo:bar');
-
-        $this->monitoredScheduledTask = MonitoredScheduledTask::factory()->create([
-            'name' => 'foo:bar',
-        ]);
-    }
-
-    /** @test */
-    public function it_will_return_false_if_it_didnt_start_or_fail_yet()
-    {
-        $this->assertFalse($this->task()->lastRunFailed());
-    }
-
-    /** @test */
-    public function it_will_return_false_if_it_did_start_but_not_fail_yet()
-    {
-        $this->monitoredScheduledTask->update(['last_started_at' => now()]);
-
-        $this->assertFalse($this->task()->lastRunFailed());
-    }
-
-    /** @test */
-    public function it_will_return_true_if_it_failed_after_it_started()
-    {
-        $this->monitoredScheduledTask->update(['last_started_at' => now()]);
-
-        TestTime::addMinute();
-
-        $this->monitoredScheduledTask->update(['last_failed_at' => now()]);
-
-        $this->assertTrue($this->task()->lastRunFailed());
-    }
-
-    /** @test */
-    public function it_will_return_false_if_it_started_after_it_failed()
-    {
-        $this->monitoredScheduledTask->update(['last_failed_at' => now()]);
-
-        TestTime::addMinute();
-
-        $this->monitoredScheduledTask->update(['last_started_at' => now()]);
-
-        $this->assertFalse($this->task()->lastRunFailed());
-    }
-
-    protected function task(): Task
-    {
-        return ScheduledTaskFactory::createForEvent($this->event);
-    }
+    return ScheduledTaskFactory::createForEvent(test()->event);
 }

--- a/tests/Support/Tasks/LastRunFailedTest.php
+++ b/tests/Support/Tasks/LastRunFailedTest.php
@@ -21,13 +21,13 @@ beforeEach(function () {
 });
 
 it('will return false if it didnt start or fail yet', function () {
-    $this->assertFalse(task()->lastRunFailed());
+    expect(task()->lastRunFailed())->toBeFalse();
 });
 
 it('will return false if it did start but not fail yet', function () {
     $this->monitoredScheduledTask->update(['last_started_at' => now()]);
 
-    $this->assertFalse(task()->lastRunFailed());
+    expect(task()->lastRunFailed())->toBeFalse();
 });
 
 it('will return true if it failed after it started', function () {
@@ -37,7 +37,7 @@ it('will return true if it failed after it started', function () {
 
     $this->monitoredScheduledTask->update(['last_failed_at' => now()]);
 
-    $this->assertTrue(task()->lastRunFailed());
+    expect(task()->lastRunFailed())->toBeTrue();
 });
 
 it('will return false if it started after it failed', function () {
@@ -47,7 +47,7 @@ it('will return false if it started after it failed', function () {
 
     $this->monitoredScheduledTask->update(['last_started_at' => now()]);
 
-    $this->assertFalse(task()->lastRunFailed());
+    expect(task()->lastRunFailed())->toBeFalse();
 });
 
 // Helpers

--- a/tests/Support/Tasks/LastRunFailedTest.php
+++ b/tests/Support/Tasks/LastRunFailedTest.php
@@ -46,7 +46,6 @@ it('will return false if it started after it failed', function () {
     expect(task()->lastRunFailed())->toBeFalse();
 });
 
-// Helpers
 function task(): Task
 {
     return ScheduledTaskFactory::createForEvent(test()->event);

--- a/tests/Support/Tasks/LastRunFailedTest.php
+++ b/tests/Support/Tasks/LastRunFailedTest.php
@@ -8,7 +8,6 @@ use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     TestTime::freeze();

--- a/tests/Support/Tasks/LastRunFailedTest.php
+++ b/tests/Support/Tasks/LastRunFailedTest.php
@@ -1,13 +1,10 @@
 <?php
 
-use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\ScheduledTaskFactory;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
-use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
-
 
 beforeEach(function () {
     TestTime::freeze();

--- a/tests/Support/Tasks/LastRunFinishedTooLateTest.php
+++ b/tests/Support/Tasks/LastRunFinishedTooLateTest.php
@@ -8,7 +8,6 @@ use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     TestTime::freeze('H:i:s', '00:00:00');

--- a/tests/Support/Tasks/LastRunFinishedTooLateTest.php
+++ b/tests/Support/Tasks/LastRunFinishedTooLateTest.php
@@ -1,13 +1,10 @@
 <?php
 
-use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\ScheduledTaskFactory;
 use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
-use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
-
 
 beforeEach(function () {
     TestTime::freeze('H:i:s', '00:00:00');

--- a/tests/Support/Tasks/LastRunFinishedTooLateTest.php
+++ b/tests/Support/Tasks/LastRunFinishedTooLateTest.php
@@ -24,34 +24,34 @@ beforeEach(function () {
 });
 
 test('a task will be consider too late if does not finish within the grace period', function () {
-    $this->assertFalse(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(5);
-    $this->assertFalse(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addSecond();
-    $this->assertTrue(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeTrue();
 });
 
 it('will reset the period', function () {
-    $this->assertFalse(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(4);
-    $this->assertFalse(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeFalse();
 
     $this->monitoredScheduledTask->update(['last_finished_at' => now()]);
 
     TestTime::addMinutes(10);
-    $this->assertFalse(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(46); // now at 1:00;
-    $this->assertFalse(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(5);
-    $this->assertFalse(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinute();
-    $this->assertTrue(task()->lastRunFinishedTooLate());
+    expect(task()->lastRunFinishedTooLate())->toBeTrue();
 });
 
 // Helpers

--- a/tests/Support/Tasks/LastRunFinishedTooLateTest.php
+++ b/tests/Support/Tasks/LastRunFinishedTooLateTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\Support\Tasks;
-
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
@@ -10,65 +8,54 @@ use Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
-class LastRunFinishedTooLateTest extends TestCase
+uses(TestCase::class);
+
+beforeEach(function () {
+    TestTime::freeze('H:i:s', '00:00:00');
+
+    $this->event = app()->make(Schedule::class)
+        ->command('foo:bar')
+        ->hourly()
+        ->graceTimeInMinutes(5);
+
+    $this->monitoredScheduledTask = MonitoredScheduledTask::factory()->create([
+        'name' => 'foo:bar',
+    ]);
+});
+
+test('a task will be consider too late if does not finish within the grace period', function () {
+    $this->assertFalse(task()->lastRunFinishedTooLate());
+
+    TestTime::addMinutes(5);
+    $this->assertFalse(task()->lastRunFinishedTooLate());
+
+    TestTime::addSecond();
+    $this->assertTrue(task()->lastRunFinishedTooLate());
+});
+
+it('will reset the period', function () {
+    $this->assertFalse(task()->lastRunFinishedTooLate());
+
+    TestTime::addMinutes(4);
+    $this->assertFalse(task()->lastRunFinishedTooLate());
+
+    $this->monitoredScheduledTask->update(['last_finished_at' => now()]);
+
+    TestTime::addMinutes(10);
+    $this->assertFalse(task()->lastRunFinishedTooLate());
+
+    TestTime::addMinutes(46); // now at 1:00;
+    $this->assertFalse(task()->lastRunFinishedTooLate());
+
+    TestTime::addMinutes(5);
+    $this->assertFalse(task()->lastRunFinishedTooLate());
+
+    TestTime::addMinute();
+    $this->assertTrue(task()->lastRunFinishedTooLate());
+});
+
+// Helpers
+function task(): Task
 {
-    private Event $event;
-
-    private MonitoredScheduledTask $monitoredScheduledTask;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        TestTime::freeze('H:i:s', '00:00:00');
-
-        $this->event = $this->app->make(Schedule::class)
-            ->command('foo:bar')
-            ->hourly()
-            ->graceTimeInMinutes(5);
-
-        $this->monitoredScheduledTask = MonitoredScheduledTask::factory()->create([
-            'name' => 'foo:bar',
-        ]);
-    }
-
-    /** @test */
-    public function a_task_will_be_consider_too_late_if_does_not_finish_within_the_grace_period()
-    {
-        $this->assertFalse($this->task()->lastRunFinishedTooLate());
-
-        TestTime::addMinutes(5);
-        $this->assertFalse($this->task()->lastRunFinishedTooLate());
-
-        TestTime::addSecond();
-        $this->assertTrue($this->task()->lastRunFinishedTooLate());
-    }
-
-    /** @test */
-    public function it_will_reset_the_period()
-    {
-        $this->assertFalse($this->task()->lastRunFinishedTooLate());
-
-        TestTime::addMinutes(4);
-        $this->assertFalse($this->task()->lastRunFinishedTooLate());
-
-        $this->monitoredScheduledTask->update(['last_finished_at' => now()]);
-
-        TestTime::addMinutes(10);
-        $this->assertFalse($this->task()->lastRunFinishedTooLate());
-
-        TestTime::addMinutes(46); // now at 1:00;
-        $this->assertFalse($this->task()->lastRunFinishedTooLate());
-
-        TestTime::addMinutes(5);
-        $this->assertFalse($this->task()->lastRunFinishedTooLate());
-
-        TestTime::addMinute();
-        $this->assertTrue($this->task()->lastRunFinishedTooLate());
-    }
-
-    protected function task(): Task
-    {
-        return ScheduledTaskFactory::createForEvent($this->event);
-    }
+    return ScheduledTaskFactory::createForEvent(test()->event);
 }

--- a/tests/Support/Tasks/LastRunFinishedTooLateTest.php
+++ b/tests/Support/Tasks/LastRunFinishedTooLateTest.php
@@ -20,38 +20,37 @@ beforeEach(function () {
 });
 
 test('a task will be consider too late if does not finish within the grace period', function () {
-    expect(task()->lastRunFinishedTooLate())->toBeFalse();
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(5);
-    expect(task()->lastRunFinishedTooLate())->toBeFalse();
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addSecond();
-    expect(task()->lastRunFinishedTooLate())->toBeTrue();
+    expect(createTask()->lastRunFinishedTooLate())->toBeTrue();
 });
 
 it('will reset the period', function () {
-    expect(task()->lastRunFinishedTooLate())->toBeFalse();
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(4);
-    expect(task()->lastRunFinishedTooLate())->toBeFalse();
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 
     $this->monitoredScheduledTask->update(['last_finished_at' => now()]);
 
     TestTime::addMinutes(10);
-    expect(task()->lastRunFinishedTooLate())->toBeFalse();
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(46); // now at 1:00;
-    expect(task()->lastRunFinishedTooLate())->toBeFalse();
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinutes(5);
-    expect(task()->lastRunFinishedTooLate())->toBeFalse();
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 
     TestTime::addMinute();
-    expect(task()->lastRunFinishedTooLate())->toBeTrue();
+    expect(createTask()->lastRunFinishedTooLate())->toBeTrue();
 });
 
-// Helpers
-function task(): Task
+function createTask(): Task
 {
     return ScheduledTaskFactory::createForEvent(test()->event);
 }

--- a/tests/Traits/UsesScheduleMonitoringModelsTest.php
+++ b/tests/Traits/UsesScheduleMonitoringModelsTest.php
@@ -3,8 +3,6 @@
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\Concerns\UsesScheduleMonitoringModels;
-use Spatie\ScheduleMonitor\Tests\TestCase;
-
 
 it('can resolve schedule monitoring models', function () {
     $model = new class() {

--- a/tests/Traits/UsesScheduleMonitoringModelsTest.php
+++ b/tests/Traits/UsesScheduleMonitoringModelsTest.php
@@ -15,6 +15,6 @@ it('can resolve schedule monitoring models', function () {
     $monitorScheduleTask = $model->getMonitoredScheduleTaskModel();
     $monitorScheduleTaskLogItem = $model->getMonitoredScheduleTaskLogItemModel();
 
-    $this->assertInstanceOf(MonitoredScheduledTask::class, $monitorScheduleTask);
-    $this->assertInstanceOf(MonitoredScheduledTaskLogItem::class, $monitorScheduleTaskLogItem);
+    expect($monitorScheduleTask)->toBeInstanceOf(MonitoredScheduledTask::class);
+    expect($monitorScheduleTaskLogItem)->toBeInstanceOf(MonitoredScheduledTaskLogItem::class);
 });

--- a/tests/Traits/UsesScheduleMonitoringModelsTest.php
+++ b/tests/Traits/UsesScheduleMonitoringModelsTest.php
@@ -5,7 +5,6 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\Concerns\UsesScheduleMonitoringModels;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can resolve schedule monitoring models', function () {
     $model = new class() {

--- a/tests/Traits/UsesScheduleMonitoringModelsTest.php
+++ b/tests/Traits/UsesScheduleMonitoringModelsTest.php
@@ -1,25 +1,20 @@
 <?php
 
-namespace Spatie\ScheduleMonitor\Tests\Traits;
-
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\Concerns\UsesScheduleMonitoringModels;
 use Spatie\ScheduleMonitor\Tests\TestCase;
 
-class UsesScheduleMonitoringModelsTest extends TestCase
-{
-    /** @test */
-    public function it_can_resolve_schedule_monitoring_models()
-    {
-        $model = new class() {
-            use UsesScheduleMonitoringModels;
-        };
+uses(TestCase::class);
 
-        $monitorScheduleTask = $model->getMonitoredScheduleTaskModel();
-        $monitorScheduleTaskLogItem = $model->getMonitoredScheduleTaskLogItemModel();
+it('can resolve schedule monitoring models', function () {
+    $model = new class() {
+        use UsesScheduleMonitoringModels;
+    };
 
-        $this->assertInstanceOf(MonitoredScheduledTask::class, $monitorScheduleTask);
-        $this->assertInstanceOf(MonitoredScheduledTaskLogItem::class, $monitorScheduleTaskLogItem);
-    }
-}
+    $monitorScheduleTask = $model->getMonitoredScheduleTaskModel();
+    $monitorScheduleTaskLogItem = $model->getMonitoredScheduleTaskLogItemModel();
+
+    $this->assertInstanceOf(MonitoredScheduledTask::class, $monitorScheduleTask);
+    $this->assertInstanceOf(MonitoredScheduledTaskLogItem::class, $monitorScheduleTaskLogItem);
+});


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-61511` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
