### PR TITLE
fix: Use `flex` and `content-repeat` on Termwind outputs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/bus": "^9.0",
         "lorisleiva/cron-translator": "^0.3.0",
         "nesbot/carbon": "^2.41.3",
-        "nunomaduro/termwind": "^1.9",
+        "nunomaduro/termwind": "^1.10",
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/bus": "^9.0",
         "lorisleiva/cron-translator": "^0.3.0",
         "nesbot/carbon": "^2.41.3",
-        "nunomaduro/termwind": "^1.10",
+        "nunomaduro/termwind": "^1.10.1",
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {

--- a/resources/views/components/task.blade.php
+++ b/resources/views/components/task.blade.php
@@ -1,15 +1,11 @@
 @props(['task'])
-<div class="space-x-1">
+<div class="flex space-x-1">
     @if ($task->name())
         <span>{{ $task->name() }}</span>
         <span class="text-gray-500 lowercase">({{ $task->type() }})</span>
     @else
         <span>{{ $task->type() }}</span>
     @endif
-    <span class="text-gray-500">
-        {{ str_repeat('.', (new \Termwind\Terminal)->width() - (
-            strlen($task->name() . $task->type() . $task->humanReadableCron()) + ($task->name() && $task->type() ? 9 : 6)
-        )) }}
-    </span>
+    <span class="text-gray-500 flex-1 content-repeat-['.']"></span>
     <span class="text-gray-500">{{ $task->humanReadableCron() }}</span>
 </div>


### PR DESCRIPTION
This PR removes the weird calculation and takes advantage of the `flex` and `content-repeat` classes from Termwind `v1.10` version.

Thanks