### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.0]
+        php: [8.2, 8.1, 8.0]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0",
         "illuminate/bus": "^9.0",
         "lorisleiva/cron-translator": "^0.3.0|^0.4.0",
-        "nesbot/carbon": "^2.41.3",
+        "nesbot/carbon": "^2.63",
         "nunomaduro/termwind": "^1.10.1",
         "spatie/laravel-package-tools": "^1.9"
     },

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "pestphp/pest-plugin": true
         }
     },
     "extra": {


### PR DESCRIPTION
## Summary

This PR adds PHP 8.2 to the tests workflow.

It also bumps the required minimum version for nesbot/carbon.

_id:php82-support/v1.0_