### PR TITLE
Add a boolean parameter to the doNotMonitor function

### DIFF
--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -113,8 +113,8 @@ class ScheduleMonitorServiceProvider extends PackageServiceProvider
             return $this;
         });
 
-        SchedulerEvent::macro('doNotMonitor', function () {
-            $this->doNotMonitor = true;
+        SchedulerEvent::macro('doNotMonitor', function (bool $bool = true) {
+            $this->doNotMonitor = $bool;
 
             return $this;
         });

--- a/tests/Support/ScheduledTestFactoryTest.php
+++ b/tests/Support/ScheduledTestFactoryTest.php
@@ -61,6 +61,12 @@ test('a task can be marked as not to be monitored', function () {
 
     $event = app()->make(Schedule::class)->command('foo:bar')->doNotMonitor();
     expect(ScheduledTaskFactory::createForEvent($event)->shouldMonitor())->toBeFalse();
+
+    $event = app()->make(Schedule::class)->command('foo:bar')->doNotMonitor(true);
+    expect(ScheduledTaskFactory::createForEvent($event)->shouldMonitor())->toBeFalse();
+
+    $event = app()->make(Schedule::class)->command('foo:bar');
+    expect(ScheduledTaskFactory::createForEvent($event)->shouldMonitor(false))->toBeTrue();
 });
 
 it('can handle timezones', function () {


### PR DESCRIPTION
Laravel offers a conditional `when` function to be used for conditional registration of scheduled commands. This function accepts a closure or a boolean and that closure will not be invoked every time the scheduler is running.

This conditional function can be very useful for enabling/disabling scheduled jobs via config like so:

```php
$schedule->command('foo:bar')
    ->dailyAt('22:15')
    ->when(config('scheduled-jobs.foo-bar'));
```

Now it is not possible for this monitor to invoke the same closure on every scheduled job, because the system needs to know when to expect a run. But wouldn't it be nice if the same config could be used to set whether or not the command should be monitored? You can do that now with this PR 🥳 

```php
$schedule->command('foo:bar')
    ->dailyAt('22:15')
    ->when(config('scheduled-jobs.foo-bar'))
    ->doNotMonitor(! config('scheduled-jobs.foo-bar'));
```