### PR TITLE
fix: allow 'dynamic' properties

### DIFF
--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ScheduleMonitor;
 
+use AllowDynamicProperties;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Console\Scheduling\Event as SchedulerEvent;
 use Illuminate\Support\Facades\Event;
@@ -18,6 +19,7 @@ use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 
+#[AllowDynamicProperties]
 class ScheduleMonitorServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void


### PR DESCRIPTION
Although they are not dynamic properties, macro's appear to be bit difficult in PHP 8.2. The error we get is:

> Creation of dynamic property Illuminate\Console\Scheduling\CallbackEvent::$monitorName is deprecated in .../vendor/spatie/laravel-schedule-monitor/src/ScheduleMonitorServiceProvider.php on line 105

Edit: on second thought, this may need to be fixed in the Macroable trait instead. 