### PR TITLE
Add note that syncing will remove other monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ This command is responsible for syncing your schedule with the database, and opt
 
 In a non-production environment you should manually run `schedule-monitor:sync`. You can verify if everything synced correctly using `schedule-monitor:list`.
 
+**Note:** Running the sync command will remove any other cron monitors that you've defined other than the application schedule.
+
 ## Usage
 
 To monitor your schedule you should first run `schedule-monitor:sync`. This command will take a look at your schedule and create an entry for each task in the `monitored_scheduled_tasks` table.


### PR DESCRIPTION
I recently had a situation where I defined a cron monitor in the OhDear UI and it was automatically deleted the next time I ran the sync command, so adding a note here to flag this for others.