### PR TITLE
fix: PHP warning about creation of dynamic properties

### DIFF
--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -20,6 +20,14 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 
 class ScheduleMonitorServiceProvider extends PackageServiceProvider
 {
+    private string $monitorName;
+
+    private int $graceTimeInMinutes;
+
+    private bool $doNotMonitor;
+
+    private bool $storeOutputInDb;
+
     public function configurePackage(Package $package): void
     {
         $package


### PR DESCRIPTION
fixes the PHP warning about the creation of dynamic properties.

Closes #93