### PR TITLE
Allow tasks to be monitored but not synced with oh dear

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,19 @@ protected function schedule(Schedule $schedule)
 }
 ```
 
+### Disabling Oh Dear for individual tasks
+
+If you want to have a task monitored by the schedule monitor, but not by Oh Dear, you can tack on `doMonitorAtOhDear` to your scheduled tasks.
+
+```php
+// in app/Console/Kernel.php
+
+protected function schedule(Schedule $schedule)
+{
+   $schedule->command('your-command')->daily()->doNotMonitorAtOhDear();
+}
+```
+
 ## Unsupported methods
 
 Currently, this package does not work for tasks that use these methods:

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -125,8 +125,8 @@ class SyncCommand extends Command
             ->whereIn(
                 'name',
                 ScheduledTasks::createForSchedule()
-                ->monitoredAtOhDear()
-                ->map->name()
+                    ->monitoredAtOhDear()
+                    ->map->name()
             )
             ->get();
 
@@ -155,8 +155,8 @@ class SyncCommand extends Command
             ->whereIn(
                 'name',
                 ScheduledTasks::createForSchedule()
-                ->monitoredAtOhDear()
-                ->map->name()
+                    ->monitoredAtOhDear()
+                    ->map->name()
             )
             ->get();
 

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -48,12 +48,12 @@ class SyncCommand extends Command
             ->map(function (Task $task) {
                 return $this->getMonitoredScheduleTaskModel()->updateOrCreate(
                     ['name' => $task->name()],
-                    [
+                    array_merge([
                         'type' => $task->type(),
                         'cron_expression' => $task->cronExpression(),
                         'timezone' => $task->timezone(),
                         'grace_time_in_minutes' => $task->graceTimeInMinutes(),
-                    ]
+                    ], $task->shouldMonitorAtOhDear() ? [] : ['ping_url' => null])
                 );
             });
 
@@ -121,7 +121,14 @@ class SyncCommand extends Command
 
     protected function syncMonitoredScheduledTaskWithOhDear(int $siteId): array
     {
-        $monitoredScheduledTasks = $this->getMonitoredScheduleTaskModel()->get();
+        $monitoredScheduledTasks = $this->getMonitoredScheduleTaskModel()
+            ->whereIn(
+                'name',
+                ScheduledTasks::createForSchedule()
+                ->monitoredAtOhDear()
+                ->map->name()
+            )
+            ->get();
 
         $cronChecks = $monitoredScheduledTasks
             ->map(function (MonitoredScheduledTask $monitoredScheduledTask) {
@@ -145,6 +152,12 @@ class SyncCommand extends Command
     {
         $tasksToRegister = $this->getMonitoredScheduleTaskModel()
             ->whereNull('registered_on_oh_dear_at')
+            ->whereIn(
+                'name',
+                ScheduledTasks::createForSchedule()
+                ->monitoredAtOhDear()
+                ->map->name()
+            )
             ->get();
 
         $cronChecks = [];

--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -26,6 +26,8 @@ class ScheduleMonitorServiceProvider extends PackageServiceProvider
 
     private bool $doNotMonitor;
 
+    private bool $doNotMonitorAtOhDear;
+
     private bool $storeOutputInDb;
 
     public function configurePackage(Package $package): void
@@ -123,6 +125,12 @@ class ScheduleMonitorServiceProvider extends PackageServiceProvider
 
         SchedulerEvent::macro('doNotMonitor', function (bool $bool = true) {
             $this->doNotMonitor = $bool;
+
+            return $this;
+        });
+
+        SchedulerEvent::macro('doNotMonitorAtOhDear', function (bool $bool = true) {
+            $this->doNotMonitorAtOhDear = $bool;
 
             return $this;
         });

--- a/src/Support/ScheduledTasks/ScheduledTasks.php
+++ b/src/Support/ScheduledTasks/ScheduledTasks.php
@@ -42,6 +42,12 @@ class ScheduledTasks
             ->values();
     }
 
+    public function monitoredAtOhDear()
+    {
+        return $this->uniqueTasks()
+            ->filter(fn (Task $task) => $task->shouldMonitorAtOhDear());
+    }
+
     public function duplicateTasks(): Collection
     {
         $uniqueTasksIds = $this->uniqueTasks()

--- a/src/Support/ScheduledTasks/Tasks/Task.php
+++ b/src/Support/ScheduledTasks/Tasks/Task.php
@@ -63,9 +63,22 @@ abstract class Task
         return ! is_null($this->monitoredScheduledTask);
     }
 
+    public function shouldMonitorAtOhDear(): bool
+    {
+        if (! isset($this->event->doNotMonitorAtOhDear)) {
+            return true;
+        }
+
+        return ! $this->event->doNotMonitorAtOhDear;
+    }
+
     public function isBeingMonitoredAtOhDear(): bool
     {
         if (! $this->isBeingMonitored()) {
+            return false;
+        }
+
+        if (! $this->shouldMonitorAtOhDear()) {
             return false;
         }
 


### PR DESCRIPTION
This PR introduces the ability to exclude individual tasks from Oh Dear but keep them in the database.

#101 

A new macro has been added to the scheduler event called `doNotMonitorAtOhDear`. This will cause it not to be synced to Oh Dear and will clear the ping_url attribute on it in the database. 