### PR TITLE
New method runsInBackground() added in  Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task:class

### DIFF
--- a/src/Support/ScheduledTasks/Tasks/Task.php
+++ b/src/Support/ScheduledTasks/Tasks/Task.php
@@ -185,4 +185,9 @@ abstract class Task
             return $this->cronExpression();
         }
     }
+
+    public function runsInBackground():bool
+    {
+        return $this->event->runInBackground;
+    }
 }


### PR DESCRIPTION
I have overwritten schedule-monitor:sync command, I need to maintain runInBackground flag in `monitored_scheduled_tasks `table for which I have added a method `runsInBackground()` in `Spatie\ScheduleMonitor\Support\ScheduledTasks\Tasks\Task:class`