### PR TITLE
fix: missing rollback for migrations

### DIFF
--- a/database/migrations/create_schedule_monitor_tables.php.stub
+++ b/database/migrations/create_schedule_monitor_tables.php.stub
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateScheduleMonitorTables extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('monitored_scheduled_tasks', function (Blueprint $table) {
             $table->bigIncrements('id');
@@ -46,5 +46,11 @@ class CreateScheduleMonitorTables extends Migration
 
             $table->timestamps();
         });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('monitored_scheduled_task_log_items');
+        Schema::dropIfExists('monitored_scheduled_tasks');
     }
 }


### PR DESCRIPTION
This ensures DB migrations can be replayed during development if development coincides with other custom migrations