### PR TITLE
Fix wrong lastRunFinishedTooLate behaviour when lastStartedAt and lastFinishedAt are within a second because of a very fast task

### DIFF
--- a/src/Support/ScheduledTasks/Tasks/Task.php
+++ b/src/Support/ScheduledTasks/Tasks/Task.php
@@ -136,10 +136,9 @@ abstract class Task
 
         $lastFinishedAt = $this->lastRunFinishedAt()
             ? $this->lastRunFinishedAt()
-            : $this->monitoredScheduledTask->created_at;
+            : $this->monitoredScheduledTask->created_at->subSecond();
 
-        $expectedNextRunStart = $this->nextRunAt($lastFinishedAt->subSecond());
-
+        $expectedNextRunStart = $this->nextRunAt($lastFinishedAt);
         $shouldHaveFinishedAt = $expectedNextRunStart->addMinutes($this->graceTimeInMinutes());
 
         return $shouldHaveFinishedAt->isPast();

--- a/tests/Support/Tasks/LastRunFinishedTooLateTest.php
+++ b/tests/Support/Tasks/LastRunFinishedTooLateTest.php
@@ -29,6 +29,14 @@ test('a task will be consider too late if does not finish within the grace perio
     expect(createTask()->lastRunFinishedTooLate())->toBeTrue();
 });
 
+test('a task will be not consider too late if the last start and finished date are the same because the task executes pretty fast', function () {
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
+
+    $this->monitoredScheduledTask->update(['last_started_at' => now(), 'last_finished_at' => now()]);
+    TestTime::addMinutes(6);
+    expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
+});
+
 it('will reset the period', function () {
     expect(createTask()->lastRunFinishedTooLate())->toBeFalse();
 


### PR DESCRIPTION
I have also added a test case to guarantee that this edge case of 2 equal dates for last start and end date is working properly.

The main problem was that the subSecond() call on the $lastFinishedAt only makes sense when it is not the actual lastRunFinishedAt date - so i moved the subSecond() call up to the "fallback" when using the created_at date.