### PR TITLE
Make `graceTimeInMinutes` configurable

### DIFF
--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -76,6 +76,10 @@ return [
          */
         'send_starting_ping' => env('OH_DEAR_SEND_STARTING_PING', false),
 
-
+        /**
+         * The amount of minutes a scheduled task is allowed to run before it is
+         * considered late.
+         */
+        'grace_time_in_minutes' => 5,
     ],
 ];

--- a/src/Support/ScheduledTasks/Tasks/Task.php
+++ b/src/Support/ScheduledTasks/Tasks/Task.php
@@ -163,7 +163,7 @@ abstract class Task
 
     public function graceTimeInMinutes()
     {
-        return $this->event->graceTimeInMinutes ?? 5;
+        return $this->event->graceTimeInMinutes ?? config('schedule-monitor.oh_dear.grace_time_in_minutes', 5);
     }
 
     public function cronExpression(): string


### PR DESCRIPTION
I have over 100 scheduled commands that all have a grace period off 30 minutes. Seemed a bit pointless/tedious to call `->graceTimeInMinutes(30)` on all of them. This change allows you to set the default grace period via configuration file if none is specified via the aforementioned function.