### PR TITLE
don't write to horizon config when not available

### DIFF
--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\ScheduleMonitor;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Console\Scheduling\Event as SchedulerEvent;
 use Illuminate\Support\Facades\Event;
+use Laravel\Horizon\Horizon;
 use OhDear\PhpSdk\OhDear;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -85,6 +86,10 @@ class ScheduleMonitorServiceProvider extends PackageServiceProvider
     protected function silenceOhDearJob(): self
     {
         if (! config('schedule-monitor.oh_dear.silence_ping_oh_dear_job_in_horizon', true)) {
+            return $this;
+        }
+
+        if (! class_exists(Horizon::class)) {
             return $this;
         }
 


### PR DESCRIPTION
When having both schedule-monitor and failed-job-monitor installed _without_ Horizon, failed-job-monitor will still regard Horizon as being installed because schedule-monitor writes to horizon config by default. Let's avoid that.

See:
https://github.com/spatie/laravel-failed-job-monitor/blob/1b4c4d3f051a1033ce6ead5433bea850bbf20878/src/Notification.php#L41