### PR TITLE
Use explicit nullable type is Task::nextRunAt

### DIFF
--- a/src/Support/ScheduledTasks/Tasks/Task.php
+++ b/src/Support/ScheduledTasks/Tasks/Task.php
@@ -99,7 +99,7 @@ abstract class Task
         return Date::instance($dateTime);
     }
 
-    public function nextRunAt(CarbonInterface $now = null): CarbonInterface
+    public function nextRunAt(?CarbonInterface $now = null): CarbonInterface
     {
         $dateTime = CronExpression::factory($this->cronExpression())->getNextRunDate(
             $now ?? now(),


### PR DESCRIPTION
Fixes PHP 8.4 deprecation warning

This could require the release of a major version as the public API changes