### PR TITLE
Fix CronExpression deprecation using constructor instead of factory method

### DIFF
--- a/src/Support/ScheduledTasks/Tasks/Task.php
+++ b/src/Support/ScheduledTasks/Tasks/Task.php
@@ -94,14 +94,14 @@ abstract class Task
 
     public function previousRunAt(): CarbonInterface
     {
-        $dateTime = CronExpression::factory($this->cronExpression())->getPreviousRunDate(now());
+        $dateTime = (new CronExpression($this->cronExpression()))->getPreviousRunDate(now());
 
         return Date::instance($dateTime);
     }
 
     public function nextRunAt(CarbonInterface $now = null): CarbonInterface
     {
-        $dateTime = CronExpression::factory($this->cronExpression())->getNextRunDate(
+        $dateTime = (new CronExpression($this->cronExpression()))->getNextRunDate(
             $now ?? now(),
             0,
             false,


### PR DESCRIPTION
CronExpression::factory is deprecated since dragonmantank/cron-expression 3.0.2. This package supports Laravel 9 which uses dragonmantank/cron-expression: ^3.1 so upgrading `CronExpression::factory($this->cronExpression())` to `(new CronExpression($this->cronExpression()))` should not be an issue