### PR TITLE
Add support for a custom ping endpoint in Oh Dear

### DIFF
--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -35,7 +35,7 @@ return [
      * Oh Dear can notify you via Mail, Slack, SMS, web hooks, ... when a
      * scheduled task does not run on time.
      *
-     * More info: https://ohdear.app/cron-checks
+     * More info: https://ohdear.app/docs/features/cron-job-monitoring
      */
     'oh_dear' => [
         /*

--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -81,5 +81,10 @@ return [
          * considered late.
          */
         'grace_time_in_minutes' => 5,
+
+        /**
+         * Which endpoint to ping on Oh Dear.
+         */
+        'endpoint_url' => env('OH_DEAR_PING_ENDPOINT_URL', 'https://ping.ohdear.app'),
     ],
 ];

--- a/database/factories/MonitoredScheduledTaskLogItemFactory.php
+++ b/database/factories/MonitoredScheduledTaskLogItemFactory.php
@@ -27,7 +27,8 @@ class MonitoredScheduledTaskLogItemFactory extends Factory
     {
         return $this->afterMaking(function(MonitoredScheduledTaskLogItem $logItem) {
             $scheduledTask = $logItem->monitoredScheduledTask;
-            $scheduledTask->ping_url = 'https://ping.ohdear.app';
+
+            $scheduledTask->ping_url = config('schedule-monitor.oh_dear.endpoint_url', 'https://ping.ohdear.app');
             $scheduledTask->save();
 
             return $logItem;

--- a/tests/Commands/SyncCommandTest.php
+++ b/tests/Commands/SyncCommandTest.php
@@ -280,3 +280,19 @@ it('will not keep old ping_urls for tasks not being sent to oh dear', function (
 
     expect($this->ohDear->getSyncedCronCheckAttributes())->toEqual([]);
 });
+
+it('will support custom ping endpoint urls in ohdear when specified in the config', function () {
+    expect(MonitoredScheduledTask::get())->toHaveCount(0);
+
+    config()->set('schedule-monitor.oh_dear.endpoint_url', 'https://custom-ping.ohdear.app');
+
+    TestKernel::registerScheduledTasks(function (Schedule $schedule) {
+        $schedule->command('dummy')->everyMinute();
+    });
+
+    $this->artisan(SyncCommand::class);
+
+    expect(MonitoredScheduledTask::get())->toHaveCount(1);
+
+    expect(MonitoredScheduledTask::first()->ping_url)->toBeString('https://custom-ping.ohdear.app/test-ping-url-dummy');
+});

--- a/tests/TestClasses/FakeOhDear.php
+++ b/tests/TestClasses/FakeOhDear.php
@@ -46,7 +46,7 @@ class FakeOhDear extends OhDear
             'server_timezone' => $serverTimezone,
         ];
 
-        $attributes['ping_url'] = 'https://ping.ohdear.app/test-ping-url-' . urlencode($attributes['name']);
+        $attributes['ping_url'] = config('schedule-monitor.oh_dear.endpoint_url') . '/test-ping-url-' . urlencode($attributes['name']);
 
         $this->syncedCronCheckAttributes[] = $attributes;
 
@@ -74,7 +74,7 @@ class FakeSite extends Site
 
         return collect($cronCheckAttributes)
             ->map(function (array $singleCronCheckAttributes) {
-                $singleCronCheckAttributes['ping_url'] = 'https://ping.ohdear.app/test-ping-url-' . urlencode($singleCronCheckAttributes['name']);
+                $singleCronCheckAttributes['ping_url'] = config('schedule-monitor.oh_dear.endpoint_url') . '/test-ping-url-' . urlencode($singleCronCheckAttributes['name']);
 
                 return new CronCheck($singleCronCheckAttributes, $this->fakeOhDear);
             })

--- a/tests/TestClasses/FakeOhDear.php
+++ b/tests/TestClasses/FakeOhDear.php
@@ -46,7 +46,7 @@ class FakeOhDear extends OhDear
             'server_timezone' => $serverTimezone,
         ];
 
-        $attributes['ping_url'] = config('schedule-monitor.oh_dear.endpoint_url') . '/test-ping-url-' . urlencode($attributes['name']);
+        $attributes['ping_url'] = config('schedule-monitor.oh_dear.endpoint_url', 'https://ping.ohdear.app') . '/test-ping-url-' . urlencode($attributes['name']);
 
         $this->syncedCronCheckAttributes[] = $attributes;
 
@@ -74,7 +74,7 @@ class FakeSite extends Site
 
         return collect($cronCheckAttributes)
             ->map(function (array $singleCronCheckAttributes) {
-                $singleCronCheckAttributes['ping_url'] = config('schedule-monitor.oh_dear.endpoint_url') . '/test-ping-url-' . urlencode($singleCronCheckAttributes['name']);
+                $singleCronCheckAttributes['ping_url'] = config('schedule-monitor.oh_dear.endpoint_url', 'https://ping.ohdear.app') . '/test-ping-url-' . urlencode($singleCronCheckAttributes['name']);
 
                 return new CronCheck($singleCronCheckAttributes, $this->fakeOhDear);
             })


### PR DESCRIPTION
This allows the payload to be sent to a custom URL. This can technically also be used to send the payload to different services than Oh Dear, making it more  compatible with 3rd party services.