### PR TITLE
Additional custom ping endpoint and config

### DIFF
--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -52,11 +52,6 @@ return [
          */
         'site_id' => env('OH_DEAR_SITE_ID'),
 
-        /**
-         * The URL of the Oh Dear API.
-         */
-        'api_url' => env('OH_DEAR_API_URL', 'https://ohdear.app/api/'),
-
         /*
          * To keep scheduled jobs as short as possible, Oh Dear will be pinged
          * via a queued job. Here you can specify the name of the queue you wish to use.
@@ -91,5 +86,10 @@ return [
          * Which endpoint to ping on Oh Dear.
          */
         'endpoint_url' => env('OH_DEAR_PING_ENDPOINT_URL'),
+
+        /**
+         * The URL of the Oh Dear API.
+         */
+        'api_url' => env('OH_DEAR_API_URL', 'https://ohdear.app/api/'),
     ],
 ];

--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -52,6 +52,11 @@ return [
          */
         'site_id' => env('OH_DEAR_SITE_ID'),
 
+        /**
+         * The URL of the Oh Dear API.
+         */
+        'api_url' => env('OH_DEAR_API_URL', 'https://ohdear.app/api/'),
+
         /*
          * To keep scheduled jobs as short as possible, Oh Dear will be pinged
          * via a queued job. Here you can specify the name of the queue you wish to use.
@@ -85,6 +90,6 @@ return [
         /**
          * Which endpoint to ping on Oh Dear.
          */
-        'endpoint_url' => env('OH_DEAR_PING_ENDPOINT_URL', 'https://ping.ohdear.app'),
+        'endpoint_url' => env('OH_DEAR_PING_ENDPOINT_URL'),
     ],
 ];

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -111,7 +111,13 @@ class SyncCommand extends Command
                         return;
                     }
 
-                    $monitoredScheduledTask->update(['ping_url' => $cronCheck->pingUrl]);
+                    $url = $cronCheck->pingUrl;
+
+                    if ($userDefinedEndpoint = config('schedule-monitor.oh_dear.endpoint_url')) {
+                        $url = rtrim($userDefinedEndpoint, '/') . '/' . $cronCheck->uuid;
+                    }
+
+                    $monitoredScheduledTask->update(['ping_url' => $url]);
                     $monitoredScheduledTask->markAsRegisteredOnOhDear();
                 }
             );

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -111,18 +111,21 @@ class SyncCommand extends Command
                         return;
                     }
 
-                    $url = $cronCheck->pingUrl;
-
-                    if ($userDefinedEndpoint = config('schedule-monitor.oh_dear.endpoint_url')) {
-                        $url = rtrim($userDefinedEndpoint, '/') . '/' . $cronCheck->uuid;
-                    }
-
-                    $monitoredScheduledTask->update(['ping_url' => $url]);
+                    $monitoredScheduledTask->update(['ping_url' => $this->pingUrl($cronCheck)]);
                     $monitoredScheduledTask->markAsRegisteredOnOhDear();
                 }
             );
 
         return $this;
+    }
+
+    protected function pingUrl(CronCheck $cronCheck): string
+    {
+        if ($userDefinedEndpoint = config('schedule-monitor.oh_dear.endpoint_url')) {
+            return rtrim($userDefinedEndpoint, '/') . '/' . $cronCheck->uuid;
+        }
+
+        return $cronCheck->pingUrl;
     }
 
     protected function syncMonitoredScheduledTaskWithOhDear(int $siteId): array

--- a/src/ScheduleMonitorServiceProvider.php
+++ b/src/ScheduleMonitorServiceProvider.php
@@ -78,7 +78,7 @@ class ScheduleMonitorServiceProvider extends PackageServiceProvider
         $this->app->bind(OhDear::class, function () {
             $apiToken = config('schedule-monitor.oh_dear.api_token');
 
-            return new OhDear($apiToken, 'https://ohdear.app/api/');
+            return new OhDear($apiToken, config('schedule-monitor.oh_dear.api_url'));
         });
 
         return $this;

--- a/tests/Commands/SyncCommandTest.php
+++ b/tests/Commands/SyncCommandTest.php
@@ -13,6 +13,9 @@ beforeEach(function () {
 });
 
 it('can sync the schedule with the db and oh dear', function () {
+
+    createUuidRange(12);
+
     TestKernel::registerScheduledTasks(function (Schedule $schedule) {
         $schedule->command('dummy')->everyMinute();
         $schedule->exec('execute')->everyFifteenMinutes();
@@ -29,7 +32,7 @@ it('can sync the schedule with the db and oh dear', function () {
         'name' => 'dummy',
         'type' => 'command',
         'cron_expression' => '* * * * *',
-        'ping_url' => 'https://ping.ohdear.app/test-ping-url-dummy',
+        'ping_url' => 'https://ping.ohdear.app/test-uuid-9',
         'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
         'grace_time_in_minutes' => 5,
         'last_pinged_at' => null,
@@ -42,7 +45,7 @@ it('can sync the schedule with the db and oh dear', function () {
         'name' => 'execute',
         'type' => 'shell',
         'cron_expression' => '*/15 * * * *',
-        'ping_url' => 'https://ping.ohdear.app/test-ping-url-execute',
+        'ping_url' => 'https://ping.ohdear.app/test-uuid-10',
         'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
         'grace_time_in_minutes' => 5,
         'last_pinged_at' => null,
@@ -55,7 +58,7 @@ it('can sync the schedule with the db and oh dear', function () {
         'name' => 'my-closure',
         'type' => 'closure',
         'cron_expression' => '0 * * * *',
-        'ping_url' => 'https://ping.ohdear.app/test-ping-url-my-closure',
+        'ping_url' => 'https://ping.ohdear.app/test-uuid-11',
         'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
         'grace_time_in_minutes' => 5,
         'last_pinged_at' => null,
@@ -68,7 +71,7 @@ it('can sync the schedule with the db and oh dear', function () {
         'name' => TestJob::class,
         'type' => 'job',
         'cron_expression' => '0 0 * * *',
-        'ping_url' => 'https://ping.ohdear.app/test-ping-url-' . urlencode(TestJob::class),
+        'ping_url' => 'https://ping.ohdear.app/test-uuid-12',
         'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
         'grace_time_in_minutes' => 5,
         'last_pinged_at' => null,
@@ -81,6 +84,8 @@ it('can sync the schedule with the db and oh dear', function () {
 });
 
 it('can use the keep old option to non destructively update the schedule with db and oh dear', function () {
+    createUuidRange(6);
+
     MonitoredScheduledTask::create([
         'name' => 'dummy-1',
         'type' => 'command',
@@ -121,7 +126,7 @@ it('can use the keep old option to non destructively update the schedule with db
         'name' => 'dummy-2',
         'type' => 'command',
         'cron_expression' => '0 * * * *',
-        'ping_url' => 'https://ping.ohdear.app/test-ping-url-dummy-2',
+        'ping_url' => 'https://ping.ohdear.app/test-uuid-5',
         'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
         'grace_time_in_minutes' => 5,
         'last_pinged_at' => null,
@@ -134,7 +139,7 @@ it('can use the keep old option to non destructively update the schedule with db
         'name' => 'dummy-3',
         'type' => 'command',
         'cron_expression' => '0 0 * * *',
-        'ping_url' => 'https://ping.ohdear.app/test-ping-url-dummy-3',
+        'ping_url' => 'https://ping.ohdear.app/test-uuid-6',
         'registered_on_oh_dear_at' => now()->format('Y-m-d H:i:s'),
         'grace_time_in_minutes' => 5,
         'last_pinged_at' => null,
@@ -294,5 +299,15 @@ it('will support custom ping endpoint urls in ohdear when specified in the confi
 
     expect(MonitoredScheduledTask::get())->toHaveCount(1);
 
-    expect(MonitoredScheduledTask::first()->ping_url)->toBeString('https://custom-ping.ohdear.app/test-ping-url-dummy');
+    $scheduledTask = MonitoredScheduledTask::first();
+
+    expect($scheduledTask->ping_url)->toBeString('https://custom-ping.ohdear.app/test-ping-url-dummy');
+
+    config()->set('schedule-monitor.oh_dear.endpoint_url', 'https://custom-ping-2.ohdear.app');
+
+    $this->artisan(SyncCommand::class);
+
+    expect(MonitoredScheduledTask::get())->toHaveCount(1);
+
+    expect($scheduledTask->refresh()->ping_url)->toBeString('https://custom-ping-2.ohdear.app/test-ping-url-dummy');
 });

--- a/tests/Commands/SyncCommandTest.php
+++ b/tests/Commands/SyncCommandTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 it('can sync the schedule with the db and oh dear', function () {
 
-    createUuidRange(12);
+    useFakeUuids();
 
     TestKernel::registerScheduledTasks(function (Schedule $schedule) {
         $schedule->command('dummy')->everyMinute();
@@ -84,7 +84,7 @@ it('can sync the schedule with the db and oh dear', function () {
 });
 
 it('can use the keep old option to non destructively update the schedule with db and oh dear', function () {
-    createUuidRange(6);
+    useFakeUuids();
 
     MonitoredScheduledTask::create([
         'name' => 'dummy-1',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,16 +6,10 @@ use Illuminate\Support\Str;
 
 uses(TestCase::class, MatchesSnapshots::class)->in(__DIR__);
 
-function createUuidRange(int $count)
+function useFakeUuids()
 {
-    if ($count < 1) {
-        throw new \Exception('Uuid range must be greater than 0');
-    }
-
-    Str::createUuidsUsingSequence(
-        collect()
-            ->range(1, $count)
-            ->map(fn ($i) => "test-uuid-{$i}")
-            ->toArray()
-    );
+    Str::createUuidsUsing(function () use (&$next) {
+        $next++;
+        return "test-uuid-{$next}";
+    });
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,5 +2,20 @@
 
 use Spatie\ScheduleMonitor\Tests\TestCase;
 use Spatie\Snapshots\MatchesSnapshots;
+use Illuminate\Support\Str;
 
 uses(TestCase::class, MatchesSnapshots::class)->in(__DIR__);
+
+function createUuidRange(int $count)
+{
+    if ($count < 1) {
+        throw new \Exception('Uuid range must be greater than 0');
+    }
+
+    Str::createUuidsUsingSequence(
+        collect()
+            ->range(1, $count)
+            ->map(fn ($i) => "test-uuid-{$i}")
+            ->toArray()
+    );
+}

--- a/tests/__snapshots__/SyncCommandTest__it_can_sync_the_schedule_with_the_db_and_oh_dear__1.yml
+++ b/tests/__snapshots__/SyncCommandTest__it_can_sync_the_schedule_with_the_db_and_oh_dear__1.yml
@@ -5,6 +5,8 @@
     grace_time_in_minutes: 5
     server_timezone: UTC
     description: ''
+    uuid: test-uuid-9
+    ping_url: 'https://ping.ohdear.app/test-uuid-9'
 -
     name: execute
     type: cron
@@ -12,6 +14,8 @@
     grace_time_in_minutes: 5
     server_timezone: UTC
     description: ''
+    uuid: test-uuid-10
+    ping_url: 'https://ping.ohdear.app/test-uuid-10'
 -
     name: my-closure
     type: cron
@@ -19,6 +23,8 @@
     grace_time_in_minutes: 5
     server_timezone: UTC
     description: ''
+    uuid: test-uuid-11
+    ping_url: 'https://ping.ohdear.app/test-uuid-11'
 -
     name: Spatie\ScheduleMonitor\Tests\TestClasses\TestJob
     type: cron
@@ -26,3 +32,5 @@
     grace_time_in_minutes: 5
     server_timezone: Asia/Kolkata
     description: ''
+    uuid: test-uuid-12
+    ping_url: 'https://ping.ohdear.app/test-uuid-12'

--- a/tests/__snapshots__/SyncCommandTest__it_can_use_the_keep_old_option_to_non_destructively_update_the_schedule_with_db_and_oh_dear__1.yml
+++ b/tests/__snapshots__/SyncCommandTest__it_can_use_the_keep_old_option_to_non_destructively_update_the_schedule_with_db_and_oh_dear__1.yml
@@ -5,7 +5,8 @@
     grace_time_in_minutes: 5
     description: ''
     server_timezone: UTC
-    ping_url: 'https://ping.ohdear.app/test-ping-url-dummy-2'
+    uuid: test-uuid-5
+    ping_url: 'https://ping.ohdear.app/test-uuid-5'
 -
     name: dummy-3
     type: cron
@@ -13,4 +14,5 @@
     grace_time_in_minutes: 5
     description: ''
     server_timezone: UTC
-    ping_url: 'https://ping.ohdear.app/test-ping-url-dummy-3'
+    uuid: test-uuid-6
+    ping_url: 'https://ping.ohdear.app/test-uuid-6'


### PR DESCRIPTION
This PR builds on #119 which updates the `ping_url` in tests but this doesn't trigger changes in the database when syncing.

- additional config for the Oh Dear API url to be used which defaults to the main production application
- removes the default `endpoint_url` which allows re-syncing and updating the ping_url based on either config or the returned Oh Dear scheduled task ping url (in that order)
- updated tests to use uuid as this is how we build the ping url when config url `endpoint_url` is used