### PR TITLE
Laravel 12 improvements: merge finished & failed events for background tasks

### DIFF
--- a/src/EventHandlers/ScheduledTaskEventSubscriber.php
+++ b/src/EventHandlers/ScheduledTaskEventSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ScheduleMonitor\EventHandlers;
 
+use Illuminate\Console\Events\ScheduledBackgroundTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskFailed;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskSkipped;
@@ -33,6 +34,11 @@ class ScheduledTaskEventSubscriber
         $events->listen(
             ScheduledTaskSkipped::class,
             fn (ScheduledTaskSkipped $event) => optional($this->getMonitoredScheduleTaskModel()->findForTask($event->task))->markAsSkipped($event)
+        );
+
+        $events->listen(
+            ScheduledBackgroundTaskFinished::class,
+            fn (ScheduledBackgroundTaskFinished $event) => optional($this->getMonitoredScheduleTaskModel()->findForTask($event->task))->markAsBackgroundTaskFinished($event)
         );
     }
 }

--- a/src/Models/MonitoredScheduledTaskLogItem.php
+++ b/src/Models/MonitoredScheduledTaskLogItem.php
@@ -33,7 +33,7 @@ class MonitoredScheduledTaskLogItem extends Model
 
     public function updateMeta(array $values): self
     {
-        $this->update(['meta' => $values]);
+        $this->update(['meta' => array_merge($this->meta ?? [], $values)]);
 
         return $this;
     }

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -8,7 +8,6 @@ use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Tests\TestClasses\FailingCommand;
-use Spatie\ScheduleMonitor\Tests\TestClasses\SuccessCommand;
 use Spatie\ScheduleMonitor\Tests\TestClasses\TestKernel;
 use Spatie\TestTime\TestTime;
 
@@ -322,7 +321,9 @@ it('extracts exception message from background task output', function () {
     File::ensureDirectoryExists(dirname($outputFile));
 
     // Simulate real Laravel exception output format
-    File::put($outputFile, <<<'OUTPUT'
+    File::put(
+        $outputFile,
+        <<<'OUTPUT'
 Starting failed command...
 
    RuntimeException

--- a/tests/TestClasses/SuccessCommand.php
+++ b/tests/TestClasses/SuccessCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\ScheduleMonitor\Tests\TestClasses;
+
+use Illuminate\Console\Command;
+
+class SuccessCommand extends Command
+{
+    public $signature = 'success-command';
+
+    public function handle()
+    {
+        $this->info('Command executed successfully');
+
+        return 0;
+    }
+}


### PR DESCRIPTION
In Laravel 12, when a command fails with an exception, BOTH ScheduledTaskFinished (exit code ≠ 0) AND ScheduledTaskFailed events fire, creating duplicate "failed" log entries. This resulted in not storing the proper failure_message or Exception details in the database.

This PR tries to address this, by counting on:
1. ScheduledTaskFinished fires first (exitCode=1) → creates failed log, stores log ID on task object
2. ScheduledTaskFailed fires immediately after → finds existing log via stored ID, merges metadata
3. Result: Single log with complete metadata from both events