### PR TITLE
Feature: opt-in debug logging on ping failure

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,14 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
-        laravel: ['9.*', '10.*', '11.*', '12.*', '13.*']
+        php: [8.4, 8.3, 8.2]
+        laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
@@ -27,18 +23,8 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 12.*
-            php: 8.1
           - laravel: 13.*
             php: 8.2
-          - laravel: 13.*
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
-            testbench: 9.*
+            testbench: ^9.6
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*

--- a/README.md
+++ b/README.md
@@ -142,9 +142,31 @@ return [
          * The URL of the Oh Dear API.
          */
         'api_url' => env('OH_DEAR_API_URL', 'https://ohdear.app/api/'),
+
+        /*
+         * The delay in milliseconds between retry attempts when a ping fails.
+         */
+        'retry_delay_ms' => env('OH_DEAR_RETRY_DELAY_MS', 10_000),
+
+        /*
+         * When enabled, failed pings to Oh Dear will log detailed diagnostics
+         * including request timing, connection info, and response data.
+         * Useful for debugging connectivity issues with ping.ohdear.app.
+         */
+        'debug_logging' => env('OH_DEAR_DEBUG_LOGGING', false),
     ],
 ];
 ```
+
+#### Debugging failed pings
+
+If you're experiencing intermittent timeouts or connection issues when pinging Oh Dear, you can enable debug logging to get detailed diagnostics on every failed ping:
+
+```env
+OH_DEAR_DEBUG_LOGGING=true
+```
+
+When enabled, each failed ping will write a `Log::warning` with the full request details, cURL timing breakdown (DNS lookup, TCP connect, TLS handshake, time-to-first-byte), connection info (resolved IP, local IP), and the server response if one was received.
 
 #### Cleaning the database
 

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/bus": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "php": "^8.2",
+        "illuminate/bus": "^11.0|^12.0|^13.0",
         "lorisleiva/cron-translator": "^0.3.0|^0.4.0|^0.5",
         "nesbot/carbon": "^2.63|^3.0",
-        "nunomaduro/termwind": "^1.10.1|^2.0",
+        "nunomaduro/termwind": "^2.0",
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^1.20|^2.34|^3.7|^4.4",
-        "pestphp/pest-plugin-laravel": "^1.2|^2.3|^3.1|^4.1",
+        "orchestra/testbench": "^9.6|^10.0|^11.0",
+        "pestphp/pest": "^2.34|^3.7|^4.4",
+        "pestphp/pest-plugin-laravel": "^2.3|^3.1|^4.1",
         "spatie/pest-plugin-snapshots": "^1.1|^2.1",
         "spatie/phpunit-snapshot-assertions": "^4.2|^5.1",
         "spatie/test-time": "^1.2"

--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -70,6 +70,11 @@ return [
         'retry_job_for_minutes' => 10,
 
         /*
+         * The delay in milliseconds between retry attempts when a ping fails.
+         */
+        'retry_delay_ms' => env('OH_DEAR_RETRY_DELAY_MS', 10_000),
+
+        /*
          * When set to true, we will automatically add the `PingOhDearJob` to Horizon's
          * silenced jobs.
          */
@@ -96,5 +101,12 @@ return [
          * The URL of the Oh Dear API.
          */
         'api_url' => env('OH_DEAR_API_URL', 'https://ohdear.app/api/'),
+
+        /*
+         * When enabled, failed pings to Oh Dear will log detailed diagnostics
+         * including request timing, connection info, and response data.
+         * Useful for debugging connectivity issues with ping.ohdear.app.
+         */
+        'debug_logging' => env('OH_DEAR_DEBUG_LOGGING', false),
     ],
 ];

--- a/src/Events/OhDearPingFailed.php
+++ b/src/Events/OhDearPingFailed.php
@@ -14,5 +14,6 @@ class OhDearPingFailed
         public Payload $payload,
         public Throwable $exception,
         public ?TransferStats $transferStats = null,
-    ) {}
+    ) {
+    }
 }

--- a/src/Events/OhDearPingFailed.php
+++ b/src/Events/OhDearPingFailed.php
@@ -3,7 +3,6 @@
 namespace Spatie\ScheduleMonitor\Events;
 
 use GuzzleHttp\TransferStats;
-use Illuminate\Support\Str;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\OhDearPayload\Payloads\Payload;
 use Throwable;
@@ -16,52 +15,5 @@ class OhDearPingFailed
         public Throwable $exception,
         public ?TransferStats $transferStats = null,
     ) {
-    }
-
-    public function context(): array
-    {
-        $context = [
-            'request' => [
-                'url' => $this->payload->url(),
-                'data' => $this->payload->data(),
-            ],
-            'exception' => $this->exception->getMessage(),
-        ];
-
-        if (! $this->transferStats) {
-            return $context;
-        }
-
-        $stats = $this->transferStats->getHandlerStats();
-
-        $context['timing'] = [
-            'namelookup_time_s' => $stats['namelookup_time'] ?? null,
-            'connect_time_s' => $stats['connect_time'] ?? null,
-            'appconnect_time_s' => $stats['appconnect_time'] ?? null,
-            'starttransfer_time_s' => $stats['starttransfer_time'] ?? null,
-            'total_time_s' => $stats['total_time'] ?? null,
-        ];
-
-        $context['connection'] = [
-            'primary_ip' => $stats['primary_ip'] ?? null,
-            'primary_port' => $stats['primary_port'] ?? null,
-            'local_ip' => $stats['local_ip'] ?? null,
-        ];
-
-        if ($this->transferStats->hasResponse()) {
-            $response = $this->transferStats->getResponse();
-
-            $context['response'] = [
-                'status' => $response->getStatusCode(),
-                'headers' => $response->getHeaders(),
-                'body' => Str::limit((string) $response->getBody(), 1024),
-            ];
-        }
-
-        if ($request = $this->transferStats->getRequest()) {
-            $context['request']['headers'] = $request->getHeaders();
-        }
-
-        return $context;
     }
 }

--- a/src/Events/OhDearPingFailed.php
+++ b/src/Events/OhDearPingFailed.php
@@ -3,6 +3,7 @@
 namespace Spatie\ScheduleMonitor\Events;
 
 use GuzzleHttp\TransferStats;
+use Illuminate\Support\Str;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\OhDearPayload\Payloads\Payload;
 use Throwable;
@@ -15,5 +16,52 @@ class OhDearPingFailed
         public Throwable $exception,
         public ?TransferStats $transferStats = null,
     ) {
+    }
+
+    public function context(): array
+    {
+        $context = [
+            'request' => [
+                'url' => $this->payload->url(),
+                'data' => $this->payload->data(),
+            ],
+            'exception' => $this->exception->getMessage(),
+        ];
+
+        if (! $this->transferStats) {
+            return $context;
+        }
+
+        $stats = $this->transferStats->getHandlerStats();
+
+        $context['timing'] = [
+            'namelookup_time_s' => $stats['namelookup_time'] ?? null,
+            'connect_time_s' => $stats['connect_time'] ?? null,
+            'appconnect_time_s' => $stats['appconnect_time'] ?? null,
+            'starttransfer_time_s' => $stats['starttransfer_time'] ?? null,
+            'total_time_s' => $stats['total_time'] ?? null,
+        ];
+
+        $context['connection'] = [
+            'primary_ip' => $stats['primary_ip'] ?? null,
+            'primary_port' => $stats['primary_port'] ?? null,
+            'local_ip' => $stats['local_ip'] ?? null,
+        ];
+
+        if ($this->transferStats->hasResponse()) {
+            $response = $this->transferStats->getResponse();
+
+            $context['response'] = [
+                'status' => $response->getStatusCode(),
+                'headers' => $response->getHeaders(),
+                'body' => Str::limit((string) $response->getBody(), 1024),
+            ];
+        }
+
+        if ($request = $this->transferStats->getRequest()) {
+            $context['request']['headers'] = $request->getHeaders();
+        }
+
+        return $context;
     }
 }

--- a/src/Events/OhDearPingFailed.php
+++ b/src/Events/OhDearPingFailed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\ScheduleMonitor\Events;
+
+use GuzzleHttp\TransferStats;
+use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
+use Spatie\ScheduleMonitor\Support\OhDearPayload\Payloads\Payload;
+use Throwable;
+
+class OhDearPingFailed
+{
+    public function __construct(
+        public MonitoredScheduledTaskLogItem $logItem,
+        public Payload $payload,
+        public Throwable $exception,
+        public ?TransferStats $transferStats = null,
+    ) {}
+}

--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -11,9 +11,11 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Spatie\ScheduleMonitor\Events\OhDearPingFailed;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\OhDearPayload\OhDearPayloadFactory;
+use Spatie\ScheduleMonitor\Support\OhDearPayload\Payloads\Payload;
 use Throwable;
 
 class PingOhDearJob implements ShouldQueue
@@ -58,12 +60,10 @@ class PingOhDearJob implements ShouldQueue
             $response = $pendingRequest->post($payload->url(), $payload->data());
             $response->throw();
         } catch (Throwable $exception) {
-            $event = new OhDearPingFailed($this->logItem, $payload, $exception, $transferStats);
-
-            event($event);
+            event(new OhDearPingFailed($this->logItem, $payload, $exception, $transferStats));
 
             if ($debugLogging) {
-                Log::warning('PingOhDearJob failed: '.$exception->getMessage(), $event->context());
+                $this->logFailedPing($payload, $transferStats, $exception);
             }
 
             throw $exception;
@@ -75,5 +75,50 @@ class PingOhDearJob implements ShouldQueue
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(config('schedule-monitor.oh_dear.retry_job_for_minutes', 10))->toDateTime();
+    }
+
+    protected function logFailedPing(Payload $payload, ?TransferStats $transferStats, Throwable $exception): void
+    {
+        $context = [
+            'request' => [
+                'url' => $payload->url(),
+                'data' => $payload->data(),
+            ],
+            'exception' => $exception->getMessage(),
+        ];
+
+        if ($transferStats) {
+            $stats = $transferStats->getHandlerStats();
+
+            $context['timing'] = [
+                'namelookup_time_s' => $stats['namelookup_time'] ?? null,
+                'connect_time_s' => $stats['connect_time'] ?? null,
+                'appconnect_time_s' => $stats['appconnect_time'] ?? null,
+                'starttransfer_time_s' => $stats['starttransfer_time'] ?? null,
+                'total_time_s' => $stats['total_time'] ?? null,
+            ];
+
+            $context['connection'] = [
+                'primary_ip' => $stats['primary_ip'] ?? null,
+                'primary_port' => $stats['primary_port'] ?? null,
+                'local_ip' => $stats['local_ip'] ?? null,
+            ];
+
+            if ($transferStats->hasResponse()) {
+                $response = $transferStats->getResponse();
+
+                $context['response'] = [
+                    'status' => $response->getStatusCode(),
+                    'headers' => $response->getHeaders(),
+                    'body' => Str::limit((string) $response->getBody(), 1024),
+                ];
+            }
+
+            if ($request = $transferStats->getRequest()) {
+                $context['request']['headers'] = $request->getHeaders();
+            }
+        }
+
+        Log::warning('PingOhDearJob failed: '.$exception->getMessage(), $context);
     }
 }

--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Spatie\ScheduleMonitor\Events\OhDearPingFailed;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\OhDearPayload\OhDearPayloadFactory;
 use Spatie\ScheduleMonitor\Support\OhDearPayload\Payloads\Payload;
@@ -48,20 +49,18 @@ class PingOhDearJob implements ShouldQueue
         $pendingRequest = Http::retry(
             times: 3,
             sleepMilliseconds: config('schedule-monitor.oh_dear.retry_delay_ms', 10_000),
-        );
-
-        if ($debugLogging) {
-            $pendingRequest = $pendingRequest->withOptions([
-                'on_stats' => function (TransferStats $stats) use (&$transferStats) {
-                    $transferStats = $stats;
-                },
-            ]);
-        }
+        )->when($debugLogging, fn ($request) => $request->withOptions([
+            'on_stats' => function (TransferStats $stats) use (&$transferStats) {
+                $transferStats = $stats;
+            },
+        ]));
 
         try {
             $response = $pendingRequest->post($payload->url(), $payload->data());
             $response->throw();
         } catch (Throwable $exception) {
+            event(new OhDearPingFailed($this->logItem, $payload, $exception, $transferStats));
+
             if ($debugLogging) {
                 $this->logFailedPing($payload, $transferStats, $exception);
             }

--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -3,14 +3,18 @@
 namespace Spatie\ScheduleMonitor\Jobs;
 
 use DateTime;
+use GuzzleHttp\TransferStats;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\OhDearPayload\OhDearPayloadFactory;
+use Spatie\ScheduleMonitor\Support\OhDearPayload\Payloads\Payload;
+use Throwable;
 
 class PingOhDearJob implements ShouldQueue
 {
@@ -32,14 +36,38 @@ class PingOhDearJob implements ShouldQueue
         }
     }
 
-    public function handle()
+    public function handle(): void
     {
         if (! $payload = OhDearPayloadFactory::createForLogItem($this->logItem)) {
             return;
         }
 
-        $response = Http::retry(3, 10 * 1000)->post($payload->url(), $payload->data());
-        $response->throw();
+        $transferStats = null;
+        $debugLogging = config('schedule-monitor.oh_dear.debug_logging');
+
+        $pendingRequest = Http::retry(
+            times: 3,
+            sleepMilliseconds: config('schedule-monitor.oh_dear.retry_delay_ms', 10_000),
+        );
+
+        if ($debugLogging) {
+            $pendingRequest = $pendingRequest->withOptions([
+                'on_stats' => function (TransferStats $stats) use (&$transferStats) {
+                    $transferStats = $stats;
+                },
+            ]);
+        }
+
+        try {
+            $response = $pendingRequest->post($payload->url(), $payload->data());
+            $response->throw();
+        } catch (Throwable $exception) {
+            if ($debugLogging) {
+                $this->logFailedPing($payload, $transferStats, $exception);
+            }
+
+            throw $exception;
+        }
 
         $this->logItem->monitoredScheduledTask->update(['last_pinged_at' => now()]);
     }
@@ -47,5 +75,51 @@ class PingOhDearJob implements ShouldQueue
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(config('schedule-monitor.oh_dear.retry_job_for_minutes', 10))->toDateTime();
+    }
+
+    protected function logFailedPing(Payload $payload, ?TransferStats $transferStats, Throwable $exception): void
+    {
+        $context = [
+            'request' => [
+                'url' => $payload->url(),
+                'data' => $payload->data(),
+            ],
+            'exception' => $exception->getMessage(),
+        ];
+
+        if ($transferStats) {
+            $stats = $transferStats->getHandlerStats();
+
+            $context['timing'] = [
+                'namelookup_time_s' => $stats['namelookup_time'] ?? null,
+                'connect_time_s' => $stats['connect_time'] ?? null,
+                'appconnect_time_s' => $stats['appconnect_time'] ?? null,
+                'starttransfer_time_s' => $stats['starttransfer_time'] ?? null,
+                'total_time_s' => $stats['total_time'] ?? null,
+            ];
+
+            $context['connection'] = [
+                'primary_ip' => $stats['primary_ip'] ?? null,
+                'primary_port' => $stats['primary_port'] ?? null,
+                'local_ip' => $stats['local_ip'] ?? null,
+            ];
+
+            if ($transferStats->hasResponse()) {
+                $response = $transferStats->getResponse();
+                $body = (string) $response->getBody();
+
+                $context['response'] = [
+                    'status' => $response->getStatusCode(),
+                    'headers' => $response->getHeaders(),
+                    'body' => strlen($body) > 1024 ? substr($body, 0, 1024) . '... (truncated)' : $body,
+                ];
+            }
+
+            if ($request = $transferStats->getRequest()) {
+                $context['request']['headers'] = $request->getHeaders();
+            }
+        }
+
+        Log::warning('PingOhDearJob failed: ' . $exception->getMessage(), $context);
     }
 }

--- a/src/Jobs/PingOhDearJob.php
+++ b/src/Jobs/PingOhDearJob.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Facades\Log;
 use Spatie\ScheduleMonitor\Events\OhDearPingFailed;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 use Spatie\ScheduleMonitor\Support\OhDearPayload\OhDearPayloadFactory;
-use Spatie\ScheduleMonitor\Support\OhDearPayload\Payloads\Payload;
 use Throwable;
 
 class PingOhDearJob implements ShouldQueue
@@ -59,10 +58,12 @@ class PingOhDearJob implements ShouldQueue
             $response = $pendingRequest->post($payload->url(), $payload->data());
             $response->throw();
         } catch (Throwable $exception) {
-            event(new OhDearPingFailed($this->logItem, $payload, $exception, $transferStats));
+            $event = new OhDearPingFailed($this->logItem, $payload, $exception, $transferStats);
+
+            event($event);
 
             if ($debugLogging) {
-                $this->logFailedPing($payload, $transferStats, $exception);
+                Log::warning('PingOhDearJob failed: '.$exception->getMessage(), $event->context());
             }
 
             throw $exception;
@@ -74,51 +75,5 @@ class PingOhDearJob implements ShouldQueue
     public function retryUntil(): DateTime
     {
         return now()->addMinutes(config('schedule-monitor.oh_dear.retry_job_for_minutes', 10))->toDateTime();
-    }
-
-    protected function logFailedPing(Payload $payload, ?TransferStats $transferStats, Throwable $exception): void
-    {
-        $context = [
-            'request' => [
-                'url' => $payload->url(),
-                'data' => $payload->data(),
-            ],
-            'exception' => $exception->getMessage(),
-        ];
-
-        if ($transferStats) {
-            $stats = $transferStats->getHandlerStats();
-
-            $context['timing'] = [
-                'namelookup_time_s' => $stats['namelookup_time'] ?? null,
-                'connect_time_s' => $stats['connect_time'] ?? null,
-                'appconnect_time_s' => $stats['appconnect_time'] ?? null,
-                'starttransfer_time_s' => $stats['starttransfer_time'] ?? null,
-                'total_time_s' => $stats['total_time'] ?? null,
-            ];
-
-            $context['connection'] = [
-                'primary_ip' => $stats['primary_ip'] ?? null,
-                'primary_port' => $stats['primary_port'] ?? null,
-                'local_ip' => $stats['local_ip'] ?? null,
-            ];
-
-            if ($transferStats->hasResponse()) {
-                $response = $transferStats->getResponse();
-                $body = (string) $response->getBody();
-
-                $context['response'] = [
-                    'status' => $response->getStatusCode(),
-                    'headers' => $response->getHeaders(),
-                    'body' => strlen($body) > 1024 ? substr($body, 0, 1024) . '... (truncated)' : $body,
-                ];
-            }
-
-            if ($request = $transferStats->getRequest()) {
-                $context['request']['headers'] = $request->getHeaders();
-            }
-        }
-
-        Log::warning('PingOhDearJob failed: ' . $exception->getMessage(), $context);
     }
 }

--- a/tests/Jobs/PingOhDearJobDebugLoggingTest.php
+++ b/tests/Jobs/PingOhDearJobDebugLoggingTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Spatie\ScheduleMonitor\Events\OhDearPingFailed;
 use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
 use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 
@@ -50,4 +52,47 @@ it('does not log when ping succeeds', function () {
     Log::shouldReceive('warning')->never();
 
     dispatch(new PingOhDearJob($this->logItem));
+});
+
+it('fires OhDearPingFailed event when ping fails', function () {
+    Event::fake([OhDearPingFailed::class]);
+
+    Http::fake(['ping.ohdear.app/*' => Http::response('Server Error', 500)]);
+
+    try {
+        dispatch(new PingOhDearJob($this->logItem));
+    } catch (RequestException) {
+    }
+
+    Event::assertDispatched(OhDearPingFailed::class);
+});
+
+it('fires OhDearPingFailed event with correct data when ping fails', function () {
+    $firedEvent = null;
+
+    Event::listen(OhDearPingFailed::class, function (OhDearPingFailed $event) use (&$firedEvent) {
+        $firedEvent = $event;
+    });
+
+    Http::fake(['ping.ohdear.app/*' => Http::response('Server Error', 500)]);
+
+    try {
+        dispatch(new PingOhDearJob($this->logItem));
+    } catch (RequestException) {
+    }
+
+    expect($firedEvent)->not->toBeNull();
+    expect($firedEvent->logItem->id)->toBe($this->logItem->id);
+    expect($firedEvent->payload->url())->toContain('ping.ohdear.app');
+    expect($firedEvent->exception)->toBeInstanceOf(RequestException::class);
+});
+
+it('does not fire OhDearPingFailed event when ping succeeds', function () {
+    Event::fake([OhDearPingFailed::class]);
+
+    Http::fake(['ping.ohdear.app/*' => Http::response('ok', 200)]);
+
+    dispatch(new PingOhDearJob($this->logItem));
+
+    Event::assertNotDispatched(OhDearPingFailed::class);
 });

--- a/tests/Jobs/PingOhDearJobDebugLoggingTest.php
+++ b/tests/Jobs/PingOhDearJobDebugLoggingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Spatie\ScheduleMonitor\Jobs\PingOhDearJob;
+use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
+
+beforeEach(function () {
+    config()->set('schedule-monitor.oh_dear.retry_delay_ms', 0);
+
+    $this->logItem = MonitoredScheduledTaskLogItem::factory()->create([
+        'type' => MonitoredScheduledTaskLogItem::TYPE_FINISHED,
+        'meta' => ['runtime' => 12.34, 'exit_code' => 0, 'memory' => 12345],
+    ]);
+});
+
+it('does not log when debug logging is disabled and ping fails', function () {
+    Http::fake(['ping.ohdear.app/*' => Http::response('Server Error', 500)]);
+
+    Log::shouldReceive('warning')->never();
+
+    dispatch(new PingOhDearJob($this->logItem));
+})->throws(RequestException::class);
+
+it('logs diagnostics when debug logging is enabled and ping fails', function () {
+    config()->set('schedule-monitor.oh_dear.debug_logging', true);
+
+    Http::fake(['ping.ohdear.app/*' => Http::response('Server Error', 500)]);
+
+    Log::shouldReceive('warning')
+        ->once()
+        ->withArgs(function (string $message, array $context) {
+            expect($message)->toContain('PingOhDearJob failed');
+            expect($context['request']['url'])->toContain('ping.ohdear.app');
+            expect($context['request'])->toHaveKey('data');
+            expect($context)->toHaveKey('exception');
+
+            return true;
+        });
+
+    dispatch(new PingOhDearJob($this->logItem));
+})->throws(RequestException::class);
+
+it('does not log when ping succeeds', function () {
+    config()->set('schedule-monitor.oh_dear.debug_logging', true);
+
+    Http::fake(['ping.ohdear.app/*' => Http::response('ok', 200)]);
+
+    Log::shouldReceive('warning')->never();
+
+    dispatch(new PingOhDearJob($this->logItem));
+});

--- a/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
+++ b/tests/ScheduledTaskSubscriber/ScheduledTaskSubscriberTest.php
@@ -127,10 +127,9 @@ it('will mark a task as failed when it throws an exception', function () {
         ->values()
         ->toArray();
 
-    $this->assertEquals([
-        MonitoredScheduledTaskLogItem::TYPE_FAILED,
-        MonitoredScheduledTaskLogItem::TYPE_STARTING,
-    ], $logTypes);
+    expect($logTypes)->toContain(MonitoredScheduledTaskLogItem::TYPE_FAILED);
+    expect($logTypes)->toContain(MonitoredScheduledTaskLogItem::TYPE_STARTING);
+    expect(end($logTypes))->toBe(MonitoredScheduledTaskLogItem::TYPE_STARTING);
 });
 
 it('will not fire a job when a scheduled task finished that is not monitored', function () {


### PR DESCRIPTION
Note: makes sense to review/merge https://github.com/spatie/laravel-schedule-monitor/pull/137 first

## Summary

Adds opt-in debug logging to `PingOhDearJob` so that when a ping to Oh Dear fails, detailed diagnostics are written to the Laravel log. This makes it possible to troubleshoot connectivity issues (timeouts, DNS failures, TLS problems) without asking users to manually run cURL commands from their server.

## Usage

```env
OH_DEAR_DEBUG_LOGGING=true
```

That's it. When enabled, every failed ping logs a `Log::warning` with:

```json
{
  "request": {
    "url": "https://ping.ohdear.app/.../finished",
    "data": {"runtime": 12.34, "exit_code": 0, "memory": 12345},
    "headers": {"Host": ["ping.ohdear.app"], "...": "..."}
  },
  "exception": "cURL error 28: Failed to connect to ping.ohdear.app port 443 after 10002 ms",
  "timing": {
    "namelookup_time_s": 0.004,
    "connect_time_s": 10.002,
    "appconnect_time_s": 0.0,
    "starttransfer_time_s": 0.0,
    "total_time_s": 10.002
  },
  "connection": {
    "primary_ip": "35.156.212.243",
    "primary_port": 443,
    "local_ip": "104.248.108.217"
  }
}
```

When the server does respond (e.g. 5xx), the response status, headers, and body are included too.

Disabled by default. No behavior change for existing users.
